### PR TITLE
fix: replace sort_by with sort_by_key for Rust 1.95 clippy

### DIFF
--- a/rsproperties/src/trie_serializer.rs
+++ b/rsproperties/src/trie_serializer.rs
@@ -101,7 +101,7 @@ impl TrieSerializer {
 
         // Sort prefixes by length (longest first)
         let mut sorted_prefix_matches: Vec<_> = builder_node.prefixes.iter().collect();
-        sorted_prefix_matches.sort_by(|a, b| b.name.len().cmp(&a.name.len()));
+        sorted_prefix_matches.sort_by_key(|b| std::cmp::Reverse(b.name.len()));
 
         self.arena
             .get_object::<TrieNodeData>(trie_offset)


### PR DESCRIPTION
## Summary
- Rust 1.95.0 added the `unnecessary_sort_by` clippy lint, which fails CI under `-D warnings` (run [25618354960](https://github.com/hiking90/rsproperties/actions/runs/25618354960)).
- Switch the prefix-length sort in `TrieSerializer` to the suggested `sort_by_key` + `std::cmp::Reverse` form. Behavior is unchanged.

## Test plan
- [ ] CI Test job (clippy + build + tests) passes on Rust stable 1.95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)