### PR TITLE
refactor: factor out entry_name_str helper, log corrupt-entry warnings

### DIFF
--- a/rsproperties/src/property_info.rs
+++ b/rsproperties/src/property_info.rs
@@ -159,6 +159,16 @@ pub(crate) fn name_from_trailing_data<I: Sized>(
     thiz: &I,
     len: Option<usize>,
 ) -> crate::errors::Result<&CStr> {
+    // SAFETY: `thiz` points into a memory-mapped property file laid out as a
+    // header (`I`) immediately followed by `len + 1` bytes of name data when
+    // `len` is `Some`, or a null-terminated C string when `len` is `None`.
+    // - `Some(len)` branch: caller guarantees `len + 1` bytes (including the
+    //   terminator) are mapped after `thiz`. `from_bytes_until_nul` reads at
+    //   most that many bytes and returns `Err` if no null is found.
+    // - `None` branch: caller guarantees the bytes after `thiz` form a
+    //   null-terminated string within the mapping. Without an upper bound,
+    //   a missing terminator would read past the mapping — this is a known
+    //   residual risk that requires propagating the buffer length to fix.
     unsafe {
         let thiz_ptr = thiz as *const _ as *const u8;
         let name_ptr = thiz_ptr.add(mem::size_of::<I>()) as _;

--- a/rsproperties/src/property_info_parser.rs
+++ b/rsproperties/src/property_info_parser.rs
@@ -34,6 +34,22 @@ where
     -1
 }
 
+/// Decodes a trie entry name into a non-empty UTF-8 string.
+///
+/// Returns `None` and skips silently for empty names (the corruption-fallback
+/// `c""` returned by `cstr()`). Returns `None` and logs a warning on UTF-8
+/// failure so corrupted entries are observable in logs.
+fn entry_name_str<'a>(name: &'a CStr, kind: &str, idx: usize) -> Option<&'a str> {
+    match name.to_str() {
+        Ok(s) if !s.is_empty() => Some(s),
+        Ok(_) => None,
+        Err(e) => {
+            warn!("{kind} entry {idx} has non-UTF-8 name: {e}");
+            None
+        }
+    }
+}
+
 #[derive(FromBytes, KnownLayout, Immutable, Debug)]
 #[repr(C, align(4))]
 pub(crate) struct PropertyEntry {
@@ -365,24 +381,25 @@ impl<'a> PropertyInfoArea<'a> {
         for i in 0..trie_node.num_prefixes() {
             let prefix = match trie_node.prefix(i as _) {
                 Ok(p) => p,
-                Err(_) => continue,
+                Err(e) => {
+                    warn!("Failed to read prefix entry {i}: {e}");
+                    continue;
+                }
             };
             if prefix.namelen > remaining_name_size as u32 {
                 continue;
             }
-            if let Ok(prefix_name) = prefix.name(self).to_str() {
-                if prefix_name.is_empty() {
-                    continue; // Empty name is not a valid prefix
+            let Some(prefix_name) = entry_name_str(prefix.name(self), "Prefix", i as usize) else {
+                continue;
+            };
+            if remaining_name.starts_with(prefix_name) {
+                if prefix.context_index != !0 {
+                    *context_index = prefix.context_index;
                 }
-                if remaining_name.starts_with(prefix_name) {
-                    if prefix.context_index != !0 {
-                        *context_index = prefix.context_index;
-                    }
-                    if prefix.type_index != !0 {
-                        *type_index = prefix.type_index;
-                    }
-                    return;
+                if prefix.type_index != !0 {
+                    *type_index = prefix.type_index;
                 }
+                return;
             }
         }
     }
@@ -432,30 +449,33 @@ impl<'a> PropertyInfoArea<'a> {
         for i in 0..trie_node.num_exact_matches() {
             let exact_match = match trie_node.exact_match(i as _) {
                 Ok(em) => em,
-                Err(_) => continue,
+                Err(e) => {
+                    warn!("Failed to read exact_match entry {i}: {e}");
+                    continue;
+                }
             };
-            if let Ok(exact_match_name) = exact_match.name(self).to_str() {
-                if exact_match_name.is_empty() {
-                    continue; // Empty name is not a valid exact match
-                }
-                if exact_match_name == remaining_name {
-                    let context_index = if exact_match.context_index != !0 {
-                        exact_match.context_index
-                    } else {
-                        return_context_index
-                    };
+            let Some(exact_match_name) =
+                entry_name_str(exact_match.name(self), "Exact match", i as usize)
+            else {
+                continue;
+            };
+            if exact_match_name == remaining_name {
+                let context_index = if exact_match.context_index != !0 {
+                    exact_match.context_index
+                } else {
+                    return_context_index
+                };
 
-                    let type_index = if exact_match.type_index != !0 {
-                        exact_match.type_index
-                    } else {
-                        return_type_index
-                    };
+                let type_index = if exact_match.type_index != !0 {
+                    exact_match.type_index
+                } else {
+                    return_type_index
+                };
 
-                    info!(
-                        "Property '{name}' resolved: context_index={context_index}, type_index={type_index}"
-                    );
-                    return (context_index, type_index);
-                }
+                info!(
+                    "Property '{name}' resolved: context_index={context_index}, type_index={type_index}"
+                );
+                return (context_index, type_index);
             }
         }
 


### PR DESCRIPTION
## Summary
The recently-merged `2ed3daa` (\"refactor: replace unwrap() calls with proper error handling\") on main silently `continue`s when `prefix()` / `exact_match()` fail or when an entry name fails UTF-8 decoding, while sibling helpers (`num_child_nodes`, `context_index`, etc.) emit `warn!` on failure. This PR makes the failure logging symmetric so data corruption is observable in logs, and consolidates the inline name-decoding checks behind a small helper.

## Changes
- **New `entry_name_str(&CStr, kind, idx) -> Option<&str>`** in [property_info_parser.rs](rsproperties/src/property_info_parser.rs): handles the \"skip empty (cstr fallback), log non-UTF-8\" pattern that previously appeared inline as `if let Ok(name) = ... { if name.is_empty() { continue; } ... }`. Used at both call sites in `check_prefix_match` and `get_property_info_indexes`, simplifying control flow with `let-else`.
- **`warn!` on `prefix()` / `exact_match()` Err** instead of silent `continue`, matching the logging style of `num_child_nodes` / `context_index` / `type_index` etc. in the same file.
- **`// SAFETY:` comment on `name_from_trailing_data`** in [property_info.rs](rsproperties/src/property_info.rs) covering both `Some(len)` and `None` branches, with the `None` (`CStr::from_ptr`) path's residual risk (no buffer bound) called out.

## What this PR is *not*
This PR was originally a much larger refactor based on stale main. After PR #17 (security improvements + unwrap removal) landed and PR #30 brought main further, the original scope was either already done on main or amounted to API churn (e.g., `LockError` → `LockPoisoned` rename, splitting `Encoding` into `MissingNulTerminator` + `Utf8`). The branch was reset to current main; only the genuine value-adds remain.

## Test plan
- [x] `cargo test --workspace --all-features` — 22 test suites pass
- [x] `cargo check --all-features` — clean
- [x] `cargo fmt --all --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)