### PR TITLE
refactor: maximise zero-copy on reads and harden property service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,9 +37,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
@@ -56,7 +56,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -67,7 +67,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -78,9 +78,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block2"
@@ -145,15 +145,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "ctrlc"
@@ -163,14 +163,14 @@ checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
  "nix",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "dispatch2"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags",
  "block2",
@@ -180,9 +180,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
  "regex",
@@ -208,14 +208,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -228,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -238,15 +238,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -255,15 +255,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -272,21 +272,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -296,7 +296,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -314,9 +313,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "30457d51cb0e68ee18184b30cd9eb8e1602a20837c321f6ea9706b94f1c681c3"
 dependencies = [
  "jiff-static",
  "log",
@@ -327,9 +326,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "05f86e4f0326c61ae6c00b04d9009aaeda644d0b5bdfbf6c67247f492f42b3f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -338,44 +337,44 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "nix"
-version = "0.31.1"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225e7cfe711e0ba79a68baeddb2982723e4235247aefce1482f2f16c27865b66"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -385,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
  "objc2-encode",
 ]
@@ -400,9 +399,9 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -412,27 +411,21 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -463,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -475,9 +468,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -486,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rsactor"
@@ -546,15 +539,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -589,18 +582,18 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -642,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -653,14 +646,14 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -700,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "utf8parse"
@@ -724,86 +717,12 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ zerocopy-derive = "0.8"
 thiserror = "2.0"
 anyhow = "1.0"
 pretty-hex = "0.4"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time", "net", "io-util", "signal"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time", "net", "io-util", "signal", "fs"] }
 rsactor = "0.15"
 
 # Dev dependencies

--- a/rsproperties-service/src/lib.rs
+++ b/rsproperties-service/src/lib.rs
@@ -21,7 +21,7 @@ pub(crate) struct ReadyMessage {}
 
 #[derive(Debug, Clone)]
 pub(crate) struct PropertyMessage {
-    pub key: String,
+    pub name: String,
     pub value: String,
 }
 
@@ -56,12 +56,12 @@ pub async fn run(
         properties_service: properties_service.actor_ref.clone(),
     });
 
-    let _ = socket_service
+    socket_service
         .actor_ref
         .ask(ReadyMessage {})
         .await
         .map_err(|e| format!("Failed to start socket service: {e}"))?;
-    let _ = properties_service
+    properties_service
         .actor_ref
         .ask(ReadyMessage {})
         .await
@@ -77,10 +77,10 @@ mod tests {
     #[test]
     fn test_property_message() {
         let msg = PropertyMessage {
-            key: "test.key".to_string(),
+            name: "test.key".to_string(),
             value: "test.value".to_string(),
         };
-        assert_eq!(msg.key, "test.key");
+        assert_eq!(msg.name, "test.key");
         assert_eq!(msg.value, "test.value");
     }
 }

--- a/rsproperties-service/src/lib.rs
+++ b/rsproperties-service/src/lib.rs
@@ -19,10 +19,24 @@ pub use properties_service::PropertiesService;
 
 pub(crate) struct ReadyMessage {}
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(crate) struct PropertyMessage {
     pub name: String,
     pub value: String,
+}
+
+// Mask `value` in `Debug` output so log-level captures don't spill
+// property contents. Property names are public knowledge (they cross the
+// AOSP wire by name and appear in `getprop` output), but values may be
+// sensitive — persisted tokens, device identifiers, configuration knobs.
+// Logging `value.len()` is enough for diagnostics.
+impl std::fmt::Debug for PropertyMessage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PropertyMessage")
+            .field("name", &self.name)
+            .field("value", &format_args!("<{} bytes>", self.value.len()))
+            .finish()
+    }
 }
 
 pub struct ServiceContext<T: Actor> {
@@ -46,7 +60,14 @@ pub async fn run(
     ),
     Box<dyn std::error::Error>,
 > {
-    rsproperties::init(config);
+    // Use `try_init` rather than `init`: if the global properties_dir /
+    // socket_dir cells were already committed (e.g. earlier service
+    // instance, double-init, hostile race), the silent `init` swallow
+    // would let the service start with the *previous* directories while
+    // the caller believes their new config took effect. `?`-propagating
+    // surfaces that drift at startup instead of producing a service bound
+    // to wrong paths.
+    rsproperties::try_init(config)?;
 
     let properties_service = properties_service::run(property_contexts_files, build_prop_files);
 

--- a/rsproperties-service/src/properties_service.rs
+++ b/rsproperties-service/src/properties_service.rs
@@ -1,7 +1,7 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs::File;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use rsactor::{Actor, ActorRef, ActorWeak};
 use rsproperties::{build_trie, load_properties_from_file, PropertyInfoEntry, SystemProperties};
@@ -25,6 +25,68 @@ where
     std::io::Error::other(e)
 }
 
+/// Synchronous initialisation: parses property_contexts files, writes the
+/// trie to `property_info`, loads build.prop files, and applies them to a
+/// freshly-mapped `SystemProperties` area.
+///
+/// Kept synchronous on purpose — every step is blocking I/O against the
+/// filesystem and we don't want to scatter `spawn_blocking` calls through
+/// the loop body. Callers invoke this once via `spawn_blocking` so the
+/// tokio worker isn't held for the duration of init.
+///
+/// Build-prop entries are collected into a `BTreeMap` so the apply order
+/// is deterministic across runs (`HashMap`'s seed-randomised iteration
+/// made the "which file wins on conflict" outcome irreproducible during
+/// debugging).
+fn init_system_properties_sync(
+    property_contexts_files: Vec<PathBuf>,
+    build_prop_files: Vec<PathBuf>,
+    dir: &Path,
+) -> std::io::Result<SystemProperties> {
+    let mut property_infos = Vec::new();
+    for file in property_contexts_files {
+        let (mut property_info, errors) =
+            PropertyInfoEntry::parse_from_file(&file, false).map_err(io_other)?;
+        if !errors.is_empty() {
+            log::error!("{errors:?}");
+        }
+        property_infos.append(&mut property_info);
+    }
+
+    let data: Vec<u8> =
+        build_trie(&property_infos, "u:object_r:build_prop:s0", "string").map_err(io_other)?;
+
+    File::create(dir.join("property_info"))?.write_all(&data)?;
+
+    // `load_properties_from_file` only accepts `&mut HashMap` (other
+    // callers depend on that signature). Re-collect into a `BTreeMap`
+    // before the apply loop so the iteration order is fully determined
+    // by the keys, not by HashMap's randomised hash seed.
+    let mut properties_unordered: HashMap<String, String> = HashMap::new();
+    for file in build_prop_files {
+        load_properties_from_file(&file, None, "u:r:init:s0", &mut properties_unordered)
+            .map_err(io_other)?;
+    }
+    let properties: BTreeMap<String, String> = properties_unordered.into_iter().collect();
+
+    let mut system_properties = SystemProperties::new_area(dir).map_err(io_other)?;
+    for (key, value) in properties.iter() {
+        match system_properties.find(key.as_str()).map_err(io_other)? {
+            Some(prop_ref) => {
+                system_properties
+                    .update(&prop_ref, value.as_str())
+                    .map_err(io_other)?;
+            }
+            None => {
+                system_properties
+                    .add(key.as_str(), value.as_str())
+                    .map_err(io_other)?;
+            }
+        }
+    }
+    Ok(system_properties)
+}
+
 impl Actor for PropertiesService {
     type Args = PropertiesServiceArgs;
     type Error = std::io::Error;
@@ -33,43 +95,16 @@ impl Actor for PropertiesService {
         args: Self::Args,
         _actor_ref: &rsactor::ActorRef<Self>,
     ) -> std::result::Result<Self, Self::Error> {
-        let mut property_infos = Vec::new();
-        for file in args.property_contexts_files {
-            let (mut property_info, errors) =
-                PropertyInfoEntry::parse_from_file(&file, false).map_err(io_other)?;
-            if !errors.is_empty() {
-                log::error!("{errors:?}");
-            }
-            property_infos.append(&mut property_info);
-        }
-
-        let data: Vec<u8> =
-            build_trie(&property_infos, "u:object_r:build_prop:s0", "string").map_err(io_other)?;
-
-        let dir = rsproperties::properties_dir();
-        File::create(dir.join("property_info"))?.write_all(&data)?;
-
-        let mut properties = HashMap::new();
-        for file in args.build_prop_files {
-            load_properties_from_file(&file, None, "u:r:init:s0", &mut properties)
-                .map_err(io_other)?;
-        }
-
-        let mut system_properties = SystemProperties::new_area(dir).map_err(io_other)?;
-        for (key, value) in properties.iter() {
-            match system_properties.find(key.as_str()).map_err(io_other)? {
-                Some(prop_ref) => {
-                    system_properties
-                        .update(&prop_ref, value.as_str())
-                        .map_err(io_other)?;
-                }
-                None => {
-                    system_properties
-                        .add(key.as_str(), value.as_str())
-                        .map_err(io_other)?;
-                }
-            }
-        }
+        let dir = rsproperties::properties_dir().to_path_buf();
+        // Filesystem + mmap + trie build all block. Run them on a blocking
+        // task so the tokio worker that polls this actor is free to drive
+        // other tasks (notably the sibling SocketService) while
+        // initialisation runs.
+        let system_properties = tokio::task::spawn_blocking(move || {
+            init_system_properties_sync(args.property_contexts_files, args.build_prop_files, &dir)
+        })
+        .await
+        .map_err(|e| std::io::Error::other(format!("init join failed: {e}")))??;
 
         Ok(PropertiesService { system_properties })
     }

--- a/rsproperties-service/src/properties_service.rs
+++ b/rsproperties-service/src/properties_service.rs
@@ -15,7 +15,15 @@ pub struct PropertiesService {
     system_properties: SystemProperties,
 }
 
-impl PropertiesService {}
+/// Wrap any error implementing the standard `Error` trait into an
+/// `io::Error` preserving the source chain. The previous `e.to_string()`
+/// flattening lost `Error::source()` and made anyhow/backtrace useless.
+fn io_other<E>(e: E) -> std::io::Error
+where
+    E: Into<Box<dyn std::error::Error + Send + Sync>>,
+{
+    std::io::Error::other(e)
+}
 
 impl Actor for PropertiesService {
     type Args = PropertiesServiceArgs;
@@ -28,7 +36,7 @@ impl Actor for PropertiesService {
         let mut property_infos = Vec::new();
         for file in args.property_contexts_files {
             let (mut property_info, errors) =
-                PropertyInfoEntry::parse_from_file(&file, false).unwrap();
+                PropertyInfoEntry::parse_from_file(&file, false).map_err(io_other)?;
             if !errors.is_empty() {
                 log::error!("{errors:?}");
             }
@@ -36,37 +44,34 @@ impl Actor for PropertiesService {
         }
 
         let data: Vec<u8> =
-            build_trie(&property_infos, "u:object_r:build_prop:s0", "string").unwrap();
+            build_trie(&property_infos, "u:object_r:build_prop:s0", "string").map_err(io_other)?;
 
         let dir = rsproperties::properties_dir();
-        File::create(dir.join("property_info"))
-            .unwrap()
-            .write_all(&data)
-            .unwrap();
+        File::create(dir.join("property_info"))?.write_all(&data)?;
 
         let mut properties = HashMap::new();
         for file in args.build_prop_files {
-            load_properties_from_file(&file, None, "u:r:init:s0", &mut properties).unwrap();
+            load_properties_from_file(&file, None, "u:r:init:s0", &mut properties)
+                .map_err(io_other)?;
         }
 
-        let mut system_properties = SystemProperties::new_area(dir).unwrap_or_else(|e| {
-            panic!("Cannot create system properties: {e}. Please check if {dir:?} exists.")
-        });
+        let mut system_properties = SystemProperties::new_area(dir).map_err(io_other)?;
         for (key, value) in properties.iter() {
-            match system_properties.find(key.as_str()).unwrap() {
+            match system_properties.find(key.as_str()).map_err(io_other)? {
                 Some(prop_ref) => {
-                    system_properties.update(&prop_ref, value.as_str()).unwrap();
+                    system_properties
+                        .update(&prop_ref, value.as_str())
+                        .map_err(io_other)?;
                 }
                 None => {
-                    system_properties.add(key.as_str(), value.as_str()).unwrap();
+                    system_properties
+                        .add(key.as_str(), value.as_str())
+                        .map_err(io_other)?;
                 }
             }
         }
 
-        Ok(PropertiesService {
-            // Initialize the service with the provided arguments
-            system_properties,
-        })
+        Ok(PropertiesService { system_properties })
     }
 
     async fn on_stop(
@@ -95,16 +100,17 @@ impl Actor for PropertiesService {
 }
 
 impl rsactor::Message<crate::ReadyMessage> for PropertiesService {
-    type Reply = bool;
+    type Reply = ();
 
     async fn handle(
         &mut self,
         _message: crate::ReadyMessage,
         _actor_ref: &ActorRef<Self>,
     ) -> Self::Reply {
-        true
     }
 }
+
+use rsproperties::wire::{validate_property_name, validate_value_len};
 
 impl rsactor::Message<crate::PropertyMessage> for PropertiesService {
     type Reply = bool;
@@ -115,35 +121,46 @@ impl rsactor::Message<crate::PropertyMessage> for PropertiesService {
         _actor_ref: &ActorRef<Self>,
     ) -> Self::Reply {
         log::debug!("Handling property message: {message:?}");
-        // Process the property message
-        let key = message.key;
+        let name = message.name;
         let value = message.value;
 
+        // Single source-of-truth for name + length policy — client and
+        // server use the same `rsproperties::wire` functions so policy
+        // drift (e.g. `>` vs `>=`) cannot reappear.
+        if let Err(e) = validate_property_name(&name) {
+            log::error!("Rejected setprop: {e}");
+            return false;
+        }
+        if let Err(e) = validate_value_len(&name, &value) {
+            log::error!("Rejected setprop: {e}");
+            return false;
+        }
+
         // Check if the property exists in the system properties
-        match self.system_properties.find(&key) {
+        match self.system_properties.find(&name) {
             Ok(Some(prop_ref)) => {
                 // Update the existing property
                 if let Err(e) = self.system_properties.update(&prop_ref, &value) {
-                    log::error!("Failed to update property '{key}': {e}");
-                    false // Indicate failure
+                    log::error!("Failed to update property '{name}': {e}");
+                    false
                 } else {
-                    log::info!("Updated property: {key} = {value}");
-                    true // Indicate success
+                    log::info!("Updated property: {name} = {value}");
+                    true
                 }
             }
             Ok(None) => {
                 // Property does not exist, add it
-                if let Err(e) = self.system_properties.add(&key, &value) {
-                    log::error!("Failed to add property '{key}': {e}");
-                    false // Indicate failure
+                if let Err(e) = self.system_properties.add(&name, &value) {
+                    log::error!("Failed to add property '{name}': {e}");
+                    false
                 } else {
-                    log::info!("Added property: {key} = {value}");
-                    true // Indicate success
+                    log::info!("Added property: {name} = {value}");
+                    true
                 }
             }
             Err(e) => {
-                log::error!("Failed to find property '{key}': {e}");
-                false // Indicate failure
+                log::error!("Failed to find property '{name}': {e}");
+                false
             }
         }
     }

--- a/rsproperties-service/src/socket_service.rs
+++ b/rsproperties-service/src/socket_service.rs
@@ -1,7 +1,8 @@
 // Copyright 2024 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-use std::path::PathBuf;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -26,6 +27,42 @@ const MAX_CONCURRENT_CLIENTS: usize = 64;
 /// clients (init, system services) complete well under this; untrusted or
 /// stuck clients are torn down rather than tying up a task indefinitely.
 const CLIENT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Sanity upper bound on a V2 wire-protocol property name length. The real
+/// AOSP limit is `PROP_NAME_MAX = 32`, but the wire format is
+/// length-prefixed so we accept up to a much higher cap here and let
+/// `validate_property_name` reject anything actually malformed. The cap
+/// only exists to bound an upfront allocation against a hostile peer.
+const MAX_WIRE_NAME_LEN: u32 = 1024;
+
+/// Sanity upper bound on a V2 wire-protocol property value length.
+/// Long-value `ro.` properties can legitimately exceed `PROP_VALUE_MAX`,
+/// so the cap is generous; the actual length policy is enforced by
+/// `validate_value_len` after the bytes are read.
+const MAX_WIRE_VALUE_LEN: u32 = 8192;
+
+/// Permissions applied to the bound Unix socket files. `0o660`
+/// (rw-rw----) matches the AOSP init policy for property service sockets
+/// — readable/writable by owner and group, denied to others. Without
+/// this explicit chmod the file would inherit the process umask, which
+/// is environment-dependent and frequently leaves the socket
+/// world-readable.
+const SOCKET_FILE_MODE: u32 = 0o660;
+
+/// Backoff applied when `accept()` returns an error. Without it, a
+/// permanent failure (EMFILE, ENFILE, listener torn down) would re-enter
+/// `on_run` immediately and spin the worker producing a high-rate log
+/// flood. 100ms is short enough to recover quickly when the condition
+/// clears, long enough to dampen the loop.
+const ACCEPT_ERROR_BACKOFF: Duration = Duration::from_millis(100);
+
+/// Applies `SOCKET_FILE_MODE` to a freshly-bound Unix socket file.
+/// `UnixListener::bind` creates the socket with permissions derived from
+/// the process umask; an explicit chmod removes that environmental
+/// dependency.
+async fn chmod_socket(path: &Path) -> std::io::Result<()> {
+    fs::set_permissions(path, std::fs::Permissions::from_mode(SOCKET_FILE_MODE)).await
+}
 
 pub struct SocketServiceArgs {
     pub socket_dir: PathBuf,
@@ -106,11 +143,13 @@ impl Actor for SocketService {
             property_socket_path.display()
         );
         let property_listener = UnixListener::bind(&property_socket_path)?;
+        chmod_socket(&property_socket_path).await?;
         trace!(
             "Binding system property service Unix domain socket: {}",
             system_socket_path.display()
         );
         let system_listener = UnixListener::bind(&system_socket_path)?;
+        chmod_socket(&system_socket_path).await?;
         info!("AsyncPropertySocketService started successfully");
 
         Ok(Self {
@@ -126,10 +165,25 @@ impl Actor for SocketService {
         &mut self,
         _actor_weak: &ActorWeak<Self>,
     ) -> std::result::Result<bool, Self::Error> {
+        // Acquire the connection permit *before* accepting. Pre-acquire
+        // means once all 64 in-flight handlers are busy the accept loop
+        // simply parks here — new connect() attempts then queue in the
+        // kernel's listen backlog (and clients block in their own
+        // connect call) instead of completing the accept, sitting idle
+        // for up to CLIENT_TIMEOUT, and then failing. That's better
+        // observable behaviour and avoids fooling clients into thinking
+        // their request was accepted.
+        let permit = match self.connection_sem.clone().acquire_owned().await {
+            Ok(p) => p,
+            Err(_) => {
+                error!("Connection semaphore closed");
+                return Ok(true);
+            }
+        };
+
         // Race accept() on both listeners. Whichever fires first wins; the
         // cancelled accept restarts on the next on_run cycle (accept is
-        // cancel-safe). Permit is acquired *after* a connection is in hand
-        // so we don't burn a permit on every losing select! arm.
+        // cancel-safe).
         let (stream, source) = tokio::select! {
             r = self.property_listener.accept() => (r, "property"),
             r = self.system_listener.accept() => (r, "system"),
@@ -138,15 +192,13 @@ impl Actor for SocketService {
         let (stream, _addr) = match stream {
             Ok(ok) => ok,
             Err(e) => {
+                // Permanent conditions (EMFILE, ENFILE, broken listener)
+                // would otherwise let `on_run` spin at full speed and
+                // saturate the log with the same error every microsecond.
+                // A small sleep both dampens the loop and gives the kernel
+                // time to recover the resource.
                 error!("Error accepting connection on {source} listener: {e}");
-                return Ok(true);
-            }
-        };
-
-        let permit = match self.connection_sem.clone().acquire_owned().await {
-            Ok(p) => p,
-            Err(_) => {
-                error!("Connection semaphore closed");
+                tokio::time::sleep(ACCEPT_ERROR_BACKOFF).await;
                 return Ok(true);
             }
         };
@@ -246,9 +298,8 @@ impl SocketService {
         let name_len = Self::read_u32(stream).await?;
         trace!("Name length: {name_len}");
 
-        if name_len > 1024 {
-            // Reasonable limit
-            error!("Name length too large: {name_len}");
+        if name_len > MAX_WIRE_NAME_LEN {
+            error!("Name length too large: {name_len} (max {MAX_WIRE_NAME_LEN})");
             Self::send_response(stream, PROP_ERROR).await?;
             return Err(rsproperties::errors::Error::FileValidation(format!(
                 "Name length too large: {name_len}"
@@ -262,9 +313,8 @@ impl SocketService {
         let value_len = Self::read_u32(stream).await?;
         trace!("Value length: {value_len}");
 
-        if value_len > 8192 {
-            // Reasonable limit for property values
-            error!("Value length too large: {value_len}");
+        if value_len > MAX_WIRE_VALUE_LEN {
+            error!("Value length too large: {value_len} (max {MAX_WIRE_VALUE_LEN})");
             Self::send_response(stream, PROP_ERROR).await?;
             return Err(rsproperties::errors::Error::FileValidation(format!(
                 "Value length too large: {value_len}"
@@ -272,9 +322,12 @@ impl SocketService {
         }
 
         let value = Self::read_string(stream, value_len as usize).await?;
-        debug!("Property value: '{value}'");
+        // Do NOT log the value; it may carry sensitive payloads. Names
+        // are public on the wire (and surface in getprop output), but
+        // values are not.
+        debug!("Property value length: {} bytes", value.len());
 
-        info!("Forwarding property: '{name}' = '{value}'");
+        info!("Forwarding property: '{name}' ({} bytes)", value.len());
 
         let property_msg = crate::PropertyMessage { name, value };
 

--- a/rsproperties-service/src/socket_service.rs
+++ b/rsproperties-service/src/socket_service.rs
@@ -1,19 +1,31 @@
 // Copyright 2024 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{fs, path::PathBuf};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
 
 use log::{debug, error, info, trace, warn};
+use tokio::fs;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{UnixListener, UnixStream};
+use tokio::sync::Semaphore;
 
 use rsactor::{Actor, ActorRef, ActorWeak};
 
 use rsproperties::errors::*;
+use rsproperties::wire::{PROP_ERROR, PROP_MSG_SETPROP2, PROP_SUCCESS};
 
-const PROP_MSG_SETPROP2: u32 = 0x00020001;
-const PROP_SUCCESS: i32 = 0;
-const PROP_ERROR: i32 = -1;
+/// Upper bound on simultaneously serviced client connections. Each accepted
+/// connection takes one permit from the semaphore; further connections wait
+/// in the kernel's accept queue. Sized to allow comfortable concurrency
+/// without permitting an unbounded fan-out of spawned tasks.
+const MAX_CONCURRENT_CLIENTS: usize = 64;
+
+/// Wall-clock timeout for an entire `handle_client` exchange. Trusted
+/// clients (init, system services) complete well under this; untrusted or
+/// stuck clients are torn down rather than tying up a task indefinitely.
+const CLIENT_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub struct SocketServiceArgs {
     pub socket_dir: PathBuf,
@@ -41,6 +53,8 @@ pub struct SocketService {
     property_listener: UnixListener,
     system_listener: UnixListener,
     properties_service: ActorRef<crate::PropertiesService>,
+    /// Limits concurrently in-flight client tasks.
+    connection_sem: Arc<Semaphore>,
 }
 
 impl Actor for SocketService {
@@ -51,10 +65,13 @@ impl Actor for SocketService {
         args: Self::Args,
         _actor_ref: &ActorRef<Self>,
     ) -> std::result::Result<Self, Self::Error> {
-        // Create parent directory if it doesn't exist
-        if !args.socket_dir.exists() {
+        // Create parent directory if it doesn't exist. `try_exists`
+        // distinguishes "doesn't exist" (Ok(false)) from "couldn't ask"
+        // (Err) — propagate the latter so permission/ENOTDIR errors don't
+        // silently degrade to `create_dir_all` racing the same error.
+        if !fs::try_exists(&args.socket_dir).await? {
             debug!("Creating parent directory: {:?}", args.socket_dir);
-            fs::create_dir_all(&args.socket_dir).map_err(rsproperties::errors::Error::new_io)?;
+            fs::create_dir_all(&args.socket_dir).await?;
         }
 
         let property_socket_path = args
@@ -64,19 +81,19 @@ impl Actor for SocketService {
             .socket_dir
             .join(rsproperties::PROPERTY_SERVICE_FOR_SYSTEM_SOCKET_NAME);
         // Remove existing socket files if they exist
-        if property_socket_path.exists() {
+        if fs::try_exists(&property_socket_path).await? {
             debug!(
                 "Removing existing property socket file: {}",
                 property_socket_path.display()
             );
-            fs::remove_file(&property_socket_path).map_err(rsproperties::errors::Error::new_io)?;
+            fs::remove_file(&property_socket_path).await?;
         }
-        if system_socket_path.exists() {
+        if fs::try_exists(&system_socket_path).await? {
             debug!(
                 "Removing existing system socket file: {}",
                 system_socket_path.display()
             );
-            fs::remove_file(&system_socket_path).map_err(rsproperties::errors::Error::new_io)?;
+            fs::remove_file(&system_socket_path).await?;
         }
         info!(
             "Property socket services successfully created at: {} and {}",
@@ -88,14 +105,12 @@ impl Actor for SocketService {
             "Binding property service Unix domain socket: {}",
             property_socket_path.display()
         );
-        let property_listener = UnixListener::bind(&property_socket_path)
-            .map_err(rsproperties::errors::Error::new_io)?;
+        let property_listener = UnixListener::bind(&property_socket_path)?;
         trace!(
             "Binding system property service Unix domain socket: {}",
             system_socket_path.display()
         );
-        let system_listener =
-            UnixListener::bind(&system_socket_path).map_err(rsproperties::errors::Error::new_io)?;
+        let system_listener = UnixListener::bind(&system_socket_path)?;
         info!("AsyncPropertySocketService started successfully");
 
         Ok(Self {
@@ -103,6 +118,7 @@ impl Actor for SocketService {
             property_listener,
             system_listener,
             properties_service: args.properties_service,
+            connection_sem: Arc::new(Semaphore::new(MAX_CONCURRENT_CLIENTS)),
         })
     }
 
@@ -110,14 +126,47 @@ impl Actor for SocketService {
         &mut self,
         _actor_weak: &ActorWeak<Self>,
     ) -> std::result::Result<bool, Self::Error> {
-        tokio::select! {
-            _ = Self::handle_socket_connections(&self.property_listener, self.properties_service.clone()) => {
-                trace!("Property socket service task completed");
+        // Race accept() on both listeners. Whichever fires first wins; the
+        // cancelled accept restarts on the next on_run cycle (accept is
+        // cancel-safe). Permit is acquired *after* a connection is in hand
+        // so we don't burn a permit on every losing select! arm.
+        let (stream, source) = tokio::select! {
+            r = self.property_listener.accept() => (r, "property"),
+            r = self.system_listener.accept() => (r, "system"),
+        };
+
+        let (stream, _addr) = match stream {
+            Ok(ok) => ok,
+            Err(e) => {
+                error!("Error accepting connection on {source} listener: {e}");
+                return Ok(true);
             }
-            _ = Self::handle_socket_connections(&self.system_listener, self.properties_service.clone()) => {
-                trace!("System property socket service task completed");
+        };
+
+        let permit = match self.connection_sem.clone().acquire_owned().await {
+            Ok(p) => p,
+            Err(_) => {
+                error!("Connection semaphore closed");
+                return Ok(true);
             }
-        }
+        };
+
+        let connection_sender = self.properties_service.clone();
+        tokio::spawn(async move {
+            let _permit = permit; // dropped when the task ends
+            match tokio::time::timeout(
+                CLIENT_TIMEOUT,
+                Self::handle_client(stream, connection_sender),
+            )
+            .await
+            {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => error!("Error handling client: {e}"),
+                Err(_elapsed) => {
+                    warn!("Client exchange timed out after {CLIENT_TIMEOUT:?}, dropping connection")
+                }
+            }
+        });
         Ok(true)
     }
 
@@ -146,45 +195,17 @@ impl Actor for SocketService {
 }
 
 impl rsactor::Message<crate::ReadyMessage> for SocketService {
-    type Reply = bool;
+    type Reply = ();
 
     async fn handle(
         &mut self,
         _message: crate::ReadyMessage,
         _actor_ref: &ActorRef<Self>,
     ) -> Self::Reply {
-        true
     }
 }
 
 impl SocketService {
-    /// Handles socket connections for a specific socket type
-    async fn handle_socket_connections(
-        listener: &UnixListener,
-        service: ActorRef<crate::PropertiesService>,
-    ) -> Result<()> {
-        // Try to accept a connection with timeout
-        let connection_result = listener.accept().await;
-
-        match connection_result {
-            Ok((stream, _)) => {
-                // Clone sender for this connection
-                let connection_sender = service.clone();
-
-                // Handle each connection in a separate task
-                tokio::spawn(async move {
-                    if let Err(e) = Self::handle_client(stream, connection_sender).await {
-                        error!("Error handling client: {e}");
-                    }
-                });
-            }
-            Err(e) => {
-                error!("Error accepting connection: {e}");
-            }
-        }
-        Ok(())
-    }
-
     /// Handles a client connection
     async fn handle_client(
         mut stream: UnixStream,
@@ -194,10 +215,7 @@ impl SocketService {
 
         // Read the command (u32)
         let mut cmd_buf = [0u8; 4];
-        stream
-            .read_exact(&mut cmd_buf)
-            .await
-            .map_err(rsproperties::errors::Error::new_io)?;
+        stream.read_exact(&mut cmd_buf).await?;
         let cmd = u32::from_ne_bytes(cmd_buf);
 
         debug!("Received command: 0x{cmd:08X}");
@@ -210,9 +228,6 @@ impl SocketService {
             _ => {
                 warn!("Unknown command received: 0x{cmd:08X}");
                 Self::send_response(&mut stream, PROP_ERROR).await?;
-                return Err(rsproperties::errors::Error::new_parse(format!(
-                    "Unknown command: 0x{cmd:08X}"
-                )));
             }
         }
 
@@ -235,7 +250,7 @@ impl SocketService {
             // Reasonable limit
             error!("Name length too large: {name_len}");
             Self::send_response(stream, PROP_ERROR).await?;
-            return Err(rsproperties::errors::Error::new_file_validation(format!(
+            return Err(rsproperties::errors::Error::FileValidation(format!(
                 "Name length too large: {name_len}"
             )));
         }
@@ -251,7 +266,7 @@ impl SocketService {
             // Reasonable limit for property values
             error!("Value length too large: {value_len}");
             Self::send_response(stream, PROP_ERROR).await?;
-            return Err(rsproperties::errors::Error::new_file_validation(format!(
+            return Err(rsproperties::errors::Error::FileValidation(format!(
                 "Value length too large: {value_len}"
             )));
         }
@@ -259,28 +274,18 @@ impl SocketService {
         let value = Self::read_string(stream, value_len as usize).await?;
         debug!("Property value: '{value}'");
 
-        // Process the property setting
-        info!("Successfully set property: '{name}' = '{value}'");
+        info!("Forwarding property: '{name}' = '{value}'");
 
-        // Send property data through channel if sender is available
-        let property_msg = crate::PropertyMessage {
-            key: name.clone(),
-            value: value.clone(),
-        };
+        let property_msg = crate::PropertyMessage { name, value };
 
         match service.ask(property_msg).await {
-            Ok(true) => {
-                debug!("Property message sent successfully: '{name}' = '{value}'");
-                Self::send_response(stream, PROP_SUCCESS).await?;
-            }
+            Ok(true) => Self::send_response(stream, PROP_SUCCESS).await?,
             Ok(false) => {
-                warn!("Property message was not processed by service: '{name}' = '{value}'");
-                // Don't fail the operation if service doesn't process it
+                warn!("Property message was not processed by service");
                 Self::send_response(stream, PROP_ERROR).await?;
             }
             Err(e) => {
                 error!("Failed to send property message through channel: {e}");
-                // Don't fail the operation if channel send fails
                 Self::send_response(stream, PROP_ERROR).await?;
             }
         }
@@ -291,10 +296,7 @@ impl SocketService {
     /// Reads a u32 value from the stream
     async fn read_u32(stream: &mut UnixStream) -> Result<u32> {
         let mut buf = [0u8; 4];
-        stream
-            .read_exact(&mut buf)
-            .await
-            .map_err(rsproperties::errors::Error::new_io)?;
+        stream.read_exact(&mut buf).await?;
         Ok(u32::from_ne_bytes(buf))
     }
 
@@ -305,30 +307,21 @@ impl SocketService {
         }
 
         let mut buf = vec![0u8; len];
-        stream
-            .read_exact(&mut buf)
-            .await
-            .map_err(rsproperties::errors::Error::new_io)?;
+        stream.read_exact(&mut buf).await?;
 
         // Remove null terminator if present
         if let Some(null_pos) = buf.iter().position(|&x| x == 0) {
             buf.truncate(null_pos);
         }
 
-        String::from_utf8(buf).map_err(|e| rsproperties::errors::Error::new_encoding(e.to_string()))
+        String::from_utf8(buf).map_err(|e| rsproperties::errors::Error::Encoding(e.to_string()))
     }
 
     /// Sends a response to the client
     async fn send_response(stream: &mut UnixStream, response: i32) -> Result<()> {
         trace!("Sending response: {response}");
-        stream
-            .write_all(&response.to_ne_bytes())
-            .await
-            .map_err(rsproperties::errors::Error::new_io)?;
-        stream
-            .flush()
-            .await
-            .map_err(rsproperties::errors::Error::new_io)?;
+        stream.write_all(&response.to_ne_bytes()).await?;
+        stream.flush().await?;
         trace!("Response sent successfully");
         Ok(())
     }
@@ -338,40 +331,17 @@ impl Drop for SocketService {
     fn drop(&mut self) {
         debug!("Cleaning up async socket service");
 
-        // Remove socket files
-        let property_socket_path = self
-            .socket_dir
-            .join(rsproperties::PROPERTY_SERVICE_SOCKET_NAME);
-        if property_socket_path.exists() {
-            if let Err(e) = fs::remove_file(&property_socket_path) {
-                warn!(
-                    "Failed to remove property socket file {}: {}",
-                    property_socket_path.display(),
-                    e
-                );
-            } else {
-                debug!(
-                    "Property socket file removed: {}",
-                    property_socket_path.display()
-                );
-            }
-        }
-
-        let system_socket_path = self
-            .socket_dir
-            .join(rsproperties::PROPERTY_SERVICE_FOR_SYSTEM_SOCKET_NAME);
-        if system_socket_path.exists() {
-            if let Err(e) = fs::remove_file(&system_socket_path) {
-                warn!(
-                    "Failed to remove system socket file {}: {}",
-                    system_socket_path.display(),
-                    e
-                );
-            } else {
-                debug!(
-                    "System socket file removed: {}",
-                    system_socket_path.display()
-                );
+        // Drop runs in sync context — keep blocking std::fs here (rare path).
+        for socket_name in [
+            rsproperties::PROPERTY_SERVICE_SOCKET_NAME,
+            rsproperties::PROPERTY_SERVICE_FOR_SYSTEM_SOCKET_NAME,
+        ] {
+            let path = self.socket_dir.join(socket_name);
+            if path.exists() {
+                match std::fs::remove_file(&path) {
+                    Ok(()) => debug!("Socket file removed: {}", path.display()),
+                    Err(e) => warn!("Failed to remove socket file {}: {e}", path.display()),
+                }
             }
         }
     }

--- a/rsproperties-service/tests/example_usage_tests.rs
+++ b/rsproperties-service/tests/example_usage_tests.rs
@@ -98,7 +98,7 @@ async fn example_error_handling() {
     fn get_required_config() -> Result<String> {
         let config: String = rsproperties::get("app.required.config")?;
         if config.is_empty() {
-            return Err(rsproperties::Error::new_not_found(
+            return Err(rsproperties::Error::NotFound(
                 "app.required.config".to_string(),
             ));
         }

--- a/rsproperties/src/build_property_parser.rs
+++ b/rsproperties/src/build_property_parser.rs
@@ -8,23 +8,13 @@ use std::io::{BufRead, BufReader};
 use std::path::Path;
 
 use crate::errors::*;
-use rustix::process::{Gid, Pid, Uid};
-
-#[cfg(any(target_os = "android", target_os = "linux"))]
-use rustix::net::UCred;
-#[cfg(target_os = "macos")]
-pub struct UCred {
-    pub pid: Pid,
-    pub uid: Uid,
-    pub gid: Gid,
-}
 
 const RESTORECON_PROPERTY: &str = "selinux.restorecon_recursive";
-// const INIT_CONTEXT: &str = "u:r:init:s0";
 
-pub fn check_permissions(_key: &str, _value: &str, _context: &str, _cr: &UCred) -> Result<()> {
+/// Placeholder for future per-property SELinux permission enforcement.
+/// Currently a no-op; see TODO in caller.
+pub fn check_permissions(_key: &str, _value: &str, _context: &str) {
     // TODO: Implement proper permission checking
-    Ok(())
 }
 
 pub fn load_properties_from_file(
@@ -34,79 +24,55 @@ pub fn load_properties_from_file(
     properties: &mut HashMap<String, String>,
 ) -> Result<()> {
     let file =
-        File::open(filename).context_with_location(format!("Failed to open to {filename:?}"))?;
+        File::open(filename).context_with_location(format!("Failed to open {filename:?}"))?;
     let reader = BufReader::new(file);
-    let has_filter = match filter {
-        Some(filter) => !filter.is_empty(),
-        None => false,
-    };
+    let filter = filter.filter(|s| !s.is_empty());
 
-    let mut line_count = 0;
-    let mut _processed_properties = 0;
-    let mut _skipped_lines = 0;
-
-    for line in reader.lines() {
-        line_count += 1;
+    for (line_count, line) in reader.lines().enumerate() {
+        let line_count = line_count + 1;
         let line = line.map_err(Error::from)?;
         let line = line.trim();
 
         if line.is_empty() || line.starts_with('#') {
-            _skipped_lines += 1;
             continue;
         }
 
-        if !has_filter && line.starts_with("import ") {
-            warn!("Line {line_count}: Import statements not implemented: {line}");
-            // let line = line[7..].trim();
-            unimplemented!("import")
-        } else {
-            let (key, value) = match line.find('=') {
-                Some(pos) => (&line[..pos], line[pos + 1..].trim()),
-                None => {
-                    _skipped_lines += 1;
+        if filter.is_none() && line.starts_with("import ") {
+            // Pre-change: `unimplemented!()` panic. A silent skip would
+            // drop dependent properties without the caller noticing, so
+            // escalate to a hard error. Callers that intentionally want
+            // to ignore imports can pass a non-empty filter.
+            error!("Line {line_count} in {filename:?}: 'import' not supported: {line}");
+            return Err(Error::Parse(format!(
+                "import statement is not supported (line {line_count} of {filename:?})"
+            )));
+        }
+
+        let (key, value) = match line.find('=') {
+            Some(pos) => (line[..pos].trim_end(), line[pos + 1..].trim()),
+            None => continue,
+        };
+
+        if let Some(filter) = filter {
+            if let Some(prefix) = filter.strip_suffix('*') {
+                if !key.starts_with(prefix) {
                     continue;
                 }
-            };
-
-            if has_filter {
-                let filter = filter.expect("filter must be valid.");
-                if filter.ends_with('*') {
-                    if let Some(prefix) = filter.strip_suffix('*') {
-                        if !key.starts_with(prefix) {
-                            continue;
-                        }
-                    }
-                } else if line != filter {
-                    continue;
-                }
-            }
-
-            if key.starts_with("ctl.") || key == "sys.powerctl" || key == RESTORECON_PROPERTY {
-                error!("Line {line_count}: Ignoring disallowed property '{key}' with special meaning in prop file '{filename:?}'");
+            } else if key != filter {
                 continue;
             }
+        }
 
-            // Create UCred with safe initialization
-            let cr = UCred {
-                pid: Pid::from_raw(1).expect("Valid PID for init process"),
-                uid: Uid::from_raw(0),
-                gid: Gid::from_raw(0),
-            };
+        if key.starts_with("ctl.") || key == "sys.powerctl" || key == RESTORECON_PROPERTY {
+            error!("Line {line_count}: Ignoring disallowed property '{key}' with special meaning in prop file '{filename:?}'");
+            continue;
+        }
 
-            match check_permissions(key, value, context, &cr) {
-                Ok(_) => {
-                    if let Some(old_value) = properties.insert(key.to_string(), value.to_string()) {
-                        warn!(
-                            "Line {line_count}: Overriding previous property '{key}':'{old_value}' with new value '{value}'"
-                        );
-                    }
-                    _processed_properties += 1;
-                }
-                Err(e) => {
-                    error!("Line {line_count}: Failed to check permissions for '{key}': {e}");
-                    continue;
-                }
-            }
+        check_permissions(key, value, context);
+        if let Some(old_value) = properties.insert(key.to_string(), value.to_string()) {
+            warn!(
+                "Line {line_count}: Overriding previous property '{key}':'{old_value}' with new value '{value}'"
+            );
         }
     }
 

--- a/rsproperties/src/context_node.rs
+++ b/rsproperties/src/context_node.rs
@@ -14,19 +14,20 @@ use crate::property_area::PropertyAreaMap;
 pub(crate) struct ContextNode {
     access_rw: bool,
     filename: PathBuf,
-    _context_offset: usize,
+    /// Lazy-initialized property area. Once a writer puts `Some`, no code
+    /// path ever resets it to `None` — this is the invariant that lets the
+    /// `*Guard` types below skip the `expect()` runtime panic. The
+    /// invariant is enforced by keeping the field private and only
+    /// exposing it through this module's API.
     property_area: RwLock<Option<PropertyAreaMap>>,
-    _no_access: bool,
 }
 
 impl ContextNode {
-    pub(crate) fn new(access_rw: bool, _context_offset: usize, filename: PathBuf) -> Self {
+    pub(crate) fn new(access_rw: bool, filename: PathBuf) -> Self {
         Self {
             access_rw,
             filename,
-            _context_offset,
             property_area: RwLock::new(None),
-            _no_access: false,
         }
     }
 
@@ -36,15 +37,13 @@ impl ContextNode {
                 "Attempted to open context node without write access: {:?}",
                 self.filename
             );
-            panic!("open() must be called with access_rw == true");
+            return Err(Error::LockError(format!(
+                "open() requires access_rw == true: {:?}",
+                self.filename
+            )));
         }
 
-        let mut prop_area = self.property_area.write().map_err(|e| {
-            Error::new_lock_error(format!(
-                "Failed to acquire write lock on property area: {}",
-                e
-            ))
-        })?;
+        let mut prop_area = self.property_area.write().map_err(lock_err("write"))?;
         if prop_area.is_some() {
             return Ok(());
         }
@@ -58,76 +57,95 @@ impl ContextNode {
         Ok(())
     }
 
-    // pub(crate) fn context_offset(&self) -> usize {
-    //     self.context_offset
-    // }
-
     pub(crate) fn property_area(&self) -> Result<PropertyAreaGuard<'_>> {
-        loop {
-            {
-                let guard = self.property_area.read().map_err(|e| {
-                    Error::new_lock_error(format!(
-                        "Failed to acquire read lock on property area: {}",
-                        e
-                    ))
-                })?;
-                if guard.is_some() {
-                    return Ok(PropertyAreaGuard { guard });
-                }
+        // Fast path: already initialized.
+        {
+            let guard = self.property_area.read().map_err(lock_err("read"))?;
+            if guard.is_some() {
+                return Ok(PropertyAreaGuard::from_initialized(guard));
             }
-            let mut guard = self.property_area.write().map_err(|e| {
-                Error::new_lock_error(format!(
-                    "Failed to acquire write lock on property area: {}",
-                    e
-                ))
-            })?;
+        }
+        // Slow path: initialize under the write lock if still empty.
+        {
+            let mut guard = self.property_area.write().map_err(lock_err("write"))?;
             if guard.is_none() {
                 *guard = Some(PropertyAreaMap::new_ro(self.filename.as_path())?);
             }
         }
+        // Re-acquire read lock for the typed guard.
+        let guard = self.property_area.read().map_err(lock_err("read"))?;
+        Ok(PropertyAreaGuard::from_initialized(guard))
     }
 
     #[cfg(feature = "builder")]
     pub(crate) fn property_area_mut(&self) -> Result<PropertyAreaMutGuard<'_>> {
-        self.property_area()?;
-        Ok(PropertyAreaMutGuard {
-            guard: self.property_area.write().map_err(|e| {
-                Error::new_lock_error(format!(
-                    "Failed to acquire write lock on property area guard: {}",
-                    e
-                ))
-            })?,
-        })
+        let mut guard = self.property_area.write().map_err(lock_err("write"))?;
+        if guard.is_none() {
+            *guard = Some(PropertyAreaMap::new_ro(self.filename.as_path())?);
+        }
+        Ok(PropertyAreaMutGuard::from_initialized(guard))
     }
 }
 
-// PropertyAreaGuard is used to get a reference to the PropertyAreaMap.
+fn lock_err<T>(kind: &'static str) -> impl Fn(std::sync::PoisonError<T>) -> Error {
+    move |e| {
+        Error::LockError(format!(
+            "Failed to acquire {kind} lock on property area: {e}"
+        ))
+    }
+}
+
+/// Read-guard that only exists once the underlying `Option` has been
+/// initialized. The `from_initialized` constructor is the single entry
+/// point and is `pub(self)` so callers in this module cannot bypass the
+/// `is_some()` check.
 pub(crate) struct PropertyAreaGuard<'a> {
     guard: RwLockReadGuard<'a, Option<PropertyAreaMap>>,
 }
 
-impl PropertyAreaGuard<'_> {
+impl<'a> PropertyAreaGuard<'a> {
+    /// Caller MUST have verified `guard.is_some()`. The `debug_assert!`
+    /// is a development-time tripwire; release builds rely on the
+    /// type-level invariant documented on `ContextNode::property_area`.
+    fn from_initialized(guard: RwLockReadGuard<'a, Option<PropertyAreaMap>>) -> Self {
+        debug_assert!(
+            guard.is_some(),
+            "PropertyAreaGuard constructed from uninitialized Option — \
+             this would have panicked in release at the access site"
+        );
+        Self { guard }
+    }
+
     pub(crate) fn property_area(&self) -> &PropertyAreaMap {
+        // SAFETY-level invariant: `from_initialized` is the only ctor; it
+        // requires `Some(...)`. No code path in this module resets the
+        // underlying `Option<PropertyAreaMap>` back to `None`.
         self.guard
             .as_ref()
-            .expect("PropertyAreaMap is not initialized")
+            .expect("PropertyAreaGuard constructed only from Some(...); see ContextNode invariant")
     }
 }
 
-// PropertyAreaMutGuard is used to get a mutable reference to the PropertyAreaMap.
-// Option<PropertyAreaMap> is initialized when the PropertyAreaMap is first accessed.
-// After that, the PropertyAreaMap is never replaced.
-// This is to ensure that the PropertyAreaMap is not replaced by another PropertyAreaMap.
+/// Write-guard counterpart of [`PropertyAreaGuard`]. Same invariant.
 #[cfg(feature = "builder")]
 pub(crate) struct PropertyAreaMutGuard<'a> {
     guard: RwLockWriteGuard<'a, Option<PropertyAreaMap>>,
 }
 
 #[cfg(feature = "builder")]
-impl PropertyAreaMutGuard<'_> {
+impl<'a> PropertyAreaMutGuard<'a> {
+    fn from_initialized(guard: RwLockWriteGuard<'a, Option<PropertyAreaMap>>) -> Self {
+        debug_assert!(
+            guard.is_some(),
+            "PropertyAreaMutGuard constructed from uninitialized Option — \
+             this would have panicked in release at the access site"
+        );
+        Self { guard }
+    }
+
     pub(crate) fn property_area_mut(&mut self) -> &mut PropertyAreaMap {
-        self.guard
-            .as_mut()
-            .expect("PropertyAreaMap is not initialized")
+        self.guard.as_mut().expect(
+            "PropertyAreaMutGuard constructed only from Some(...); see ContextNode invariant",
+        )
     }
 }

--- a/rsproperties/src/contexts_serialized.rs
+++ b/rsproperties/src/contexts_serialized.rs
@@ -12,7 +12,22 @@ use rustix::fs;
 use crate::context_node::PropertyAreaMutGuard;
 use crate::context_node::{ContextNode, PropertyAreaGuard};
 use crate::property_area::{PropertyArea, PropertyAreaMap};
-use crate::property_info_parser::PropertyInfoAreaFile;
+use crate::property_info_parser::{PropertyInfoArea, PropertyInfoAreaFile};
+
+/// Decodes one `ContextNode` entry from the property-info area. Returns
+/// `Err` on corrupt offset, missing NUL terminator, or non-UTF-8 name —
+/// callers tag the slot as `None` so the surrounding `Vec<Option<_>>`
+/// indices stay aligned with the parser's `context_index` values.
+fn try_build_context_node(
+    area: &PropertyInfoArea<'_>,
+    dirname: &Path,
+    writable: bool,
+    i: usize,
+) -> Result<ContextNode> {
+    let context_offset = area.context_offset(i)?;
+    let context_name = area.cstr(context_offset).to_str()?;
+    Ok(ContextNode::new(writable, dirname.join(context_name)))
+}
 
 // Pre-defined CStr constants to avoid unsafe code at runtime
 // Using const_str macro or safer compile-time construction
@@ -20,7 +35,10 @@ const PROPERTIES_SERIAL_CONTEXT: &CStr = c"u:object_r:properties_serial:s0";
 
 pub(crate) struct ContextsSerialized {
     property_info_area_file: PropertyInfoAreaFile,
-    context_nodes: Vec<ContextNode>,
+    /// `None` slots are corrupt context entries that were skipped during init.
+    /// We keep the slot so that `context_index` values produced by the
+    /// property-info parser line up with the vector's indices.
+    context_nodes: Vec<Option<ContextNode>>,
     serial_property_area_map: PropertyAreaMap,
 }
 
@@ -43,13 +61,16 @@ impl ContextsSerialized {
 
         let property_info_area = property_info_area_file.property_info_area();
         let num_context_nodes = property_info_area.num_contexts();
-        let mut context_nodes = Vec::with_capacity(num_context_nodes);
+        let mut context_nodes: Vec<Option<ContextNode>> = Vec::with_capacity(num_context_nodes);
 
         for i in 0..num_context_nodes {
-            let context_offset = property_info_area.context_offset(i)?;
-            let context_name = property_info_area.cstr(context_offset).to_str()?;
-            let filename = dirname.join(context_name);
-            context_nodes.push(ContextNode::new(writable, context_offset, filename))
+            match try_build_context_node(&property_info_area, dirname.as_path(), writable, i) {
+                Ok(n) => context_nodes.push(Some(n)),
+                Err(e) => {
+                    warn!("context entry {i} skipped: {e}");
+                    context_nodes.push(None);
+                }
+            }
         }
 
         let serial_property_area_map = if writable {
@@ -64,7 +85,7 @@ impl ContextsSerialized {
 
             *fsetxattr_failed = false;
 
-            for node in context_nodes.iter_mut() {
+            for node in context_nodes.iter_mut().flatten() {
                 node.open(fsetxattr_failed)?;
             }
 
@@ -116,10 +137,13 @@ impl ContextsSerialized {
                 index,
                 self.context_nodes.len()
             );
-            return Err(Error::new_not_found(name.to_owned()));
+            return Err(Error::NotFound(name.to_owned()));
         }
 
-        let context_node = &self.context_nodes[index as usize];
+        let context_node = self.context_nodes[index as usize].as_ref().ok_or_else(|| {
+            error!("Context entry {index} for property {name} was skipped during init");
+            Error::NotFound(name.to_owned())
+        })?;
 
         match context_node.property_area() {
             Ok(area) => Ok((area, index)),
@@ -147,12 +171,15 @@ impl ContextsSerialized {
                 index,
                 self.context_nodes.len()
             );
-            return Err(Error::new_not_found(format!(
+            return Err(Error::NotFound(format!(
                 "Could not find context for property {name}"
             )));
         }
 
-        let context_node = &self.context_nodes[index as usize];
+        let context_node = self.context_nodes[index as usize].as_ref().ok_or_else(|| {
+            error!("Context entry {index} for property {name} was skipped during init");
+            Error::NotFound(format!("Could not find context for property {name}"))
+        })?;
 
         match context_node.property_area_mut() {
             Ok(area) => Ok((area, index)),
@@ -162,10 +189,6 @@ impl ContextsSerialized {
             }
         }
     }
-
-    // pub(crate) fn get_serial_prop_name(&self) -> Result<&PropertyAreaMap> {
-    //     unimplemented!("get_serial_prop_name")
-    // }
 
     pub(crate) fn serial_prop_area(&self) -> &PropertyArea {
         self.serial_property_area_map.property_area()
@@ -178,12 +201,19 @@ impl ContextsSerialized {
                 context_index,
                 self.context_nodes.len()
             );
-            return Err(Error::new_parse(format!(
+            return Err(Error::Parse(format!(
                 "Invalid context index: {context_index}"
             )));
         }
 
-        let context_node = &self.context_nodes[context_index as usize];
+        let context_node = self.context_nodes[context_index as usize]
+            .as_ref()
+            .ok_or_else(|| {
+                error!("Context entry {context_index} was skipped during init");
+                Error::NotFound(format!(
+                    "Context entry {context_index} is unavailable (corrupt at init)"
+                ))
+            })?;
         match context_node.property_area() {
             Ok(area) => Ok(area),
             Err(e) => {
@@ -204,12 +234,19 @@ impl ContextsSerialized {
                 context_index,
                 self.context_nodes.len()
             );
-            return Err(Error::new_parse(format!(
+            return Err(Error::Parse(format!(
                 "Invalid context index: {context_index}"
             )));
         }
 
-        let context_node = &self.context_nodes[context_index as usize];
+        let context_node = self.context_nodes[context_index as usize]
+            .as_ref()
+            .ok_or_else(|| {
+                error!("Context entry {context_index} was skipped during init");
+                Error::NotFound(format!(
+                    "Context entry {context_index} is unavailable (corrupt at init)"
+                ))
+            })?;
         match context_node.property_area_mut() {
             Ok(area) => Ok(area),
             Err(e) => {

--- a/rsproperties/src/errors.rs
+++ b/rsproperties/src/errors.rs
@@ -8,10 +8,10 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("I/O error: {0}")]
-    Io(std::io::Error),
+    Io(#[from] std::io::Error),
 
     #[error("System error: {0}")]
-    Errno(rustix::io::Errno),
+    Errno(#[from] rustix::io::Errno),
 
     #[error("Property not found: {0}")]
     NotFound(String),
@@ -39,106 +39,38 @@ pub enum Error {
 
     #[error("Lock error: {0}")]
     LockError(String),
-}
 
-impl Error {
-    pub fn new_not_found(key: String) -> Error {
-        Error::NotFound(key)
-    }
-
-    pub fn new_encoding(msg: String) -> Error {
-        Error::Encoding(msg)
-    }
-
-    pub fn new_parse(msg: String) -> Error {
-        Error::Parse(msg)
-    }
-
-    pub fn new_file_validation(msg: String) -> Error {
-        Error::FileValidation(msg)
-    }
-
-    pub fn new_conversion(msg: String) -> Error {
-        Error::Conversion(msg)
-    }
-
-    pub fn new_permission_denied(msg: String) -> Error {
-        Error::PermissionDenied(msg)
-    }
-
-    pub fn new_file_size(msg: String) -> Error {
-        Error::FileSize(msg)
-    }
-
-    pub fn new_file_ownership(msg: String) -> Error {
-        Error::FileOwnership(msg)
-    }
-
-    pub fn new_lock_error(msg: String) -> Error {
-        Error::LockError(msg)
-    }
-
-    pub fn new_io(io_error: std::io::Error) -> Error {
-        let error = Error::Io(io_error);
-        log::error!("I/O error: {error}");
-        error
-    }
-
-    pub fn new_errno(errno: rustix::io::Errno) -> Error {
-        let error = Error::Errno(errno);
-        log::error!("System error: {error}");
-        error
-    }
-}
-
-impl From<rustix::io::Errno> for Error {
-    fn from(source: rustix::io::Errno) -> Self {
-        let error = Error::Errno(source);
-        log::error!("Converting errno to Error: {source}");
-        error
-    }
-}
-
-impl From<std::io::Error> for Error {
-    fn from(source: std::io::Error) -> Self {
-        let error = Error::Io(source);
-        log::error!("Converting I/O error to Error: {error}");
-        error
-    }
+    /// A wrapped error with caller-supplied context and the source error
+    /// preserved for `Error::source()` chain traversal.
+    #[error("{msg} (at {location}): {source}")]
+    Context {
+        msg: String,
+        location: &'static std::panic::Location<'static>,
+        #[source]
+        source: Box<Error>,
+    },
 }
 
 impl From<std::str::Utf8Error> for Error {
     fn from(source: std::str::Utf8Error) -> Self {
-        let error_msg = format!("UTF-8 conversion error: {source}");
-        log::error!("{error_msg}");
-        Error::Encoding(error_msg)
+        Error::Encoding(format!("UTF-8 conversion error: {source}"))
     }
 }
 
 impl From<std::ffi::OsString> for Error {
     fn from(source: std::ffi::OsString) -> Self {
-        let error_msg = format!("OsString conversion error: {source:?}");
-        log::error!("{error_msg}");
-        Error::Conversion(error_msg)
-    }
-}
-
-impl From<&str> for Error {
-    fn from(source: &str) -> Self {
-        log::error!("String error: {source}");
-        Error::Parse(source.to_owned())
+        Error::Conversion(format!("OsString conversion error: {source:?}"))
     }
 }
 
 impl From<ParseIntError> for Error {
     fn from(source: ParseIntError) -> Self {
-        let error_msg = format!("Parse integer error: {source}");
-        log::error!("{error_msg}");
-        Error::Parse(error_msg)
+        Error::Parse(format!("Parse integer error: {source}"))
     }
 }
 
 pub trait ContextWithLocation<T> {
+    #[track_caller]
     fn context_with_location(self, msg: impl Into<String>) -> Result<T>;
 }
 
@@ -146,9 +78,14 @@ impl<T, E> ContextWithLocation<T> for std::result::Result<T, E>
 where
     E: Into<Error>,
 {
+    #[track_caller]
     fn context_with_location(self, msg: impl Into<String>) -> Result<T> {
-        self.map_err(|e| e.into())
-            .map_err(|_| Error::new_file_validation(msg.into()))
+        let location = std::panic::Location::caller();
+        self.map_err(|e| Error::Context {
+            msg: msg.into(),
+            location,
+            source: Box::new(e.into()),
+        })
     }
 }
 
@@ -180,7 +117,7 @@ pub fn validate_file_metadata(
             path
         );
         log::error!("{error_msg}");
-        return Err(Error::new_file_size(error_msg));
+        return Err(Error::FileSize(error_msg));
     }
 
     #[cfg(any(target_os = "android", target_os = "linux"))]
@@ -198,7 +135,7 @@ pub fn validate_file_metadata(
             path
         );
         log::error!("{error_msg}");
-        return Err(Error::new_permission_denied(error_msg));
+        return Err(Error::PermissionDenied(error_msg));
     }
 
     // In production mode, also check ownership
@@ -216,7 +153,7 @@ pub fn validate_file_metadata(
             path
         );
         log::error!("{error_msg}");
-        return Err(Error::new_file_ownership(error_msg));
+        return Err(Error::FileOwnership(error_msg));
     }
 
     Ok(())
@@ -225,23 +162,28 @@ pub fn validate_file_metadata(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use anyhow::Context;
+
+    #[test]
+    fn test_error_io_via_question_mark() {
+        let err = try_open_file().unwrap_err();
+        assert!(matches!(err, Error::Io(_)));
+        assert!(std::error::Error::source(&err).is_some());
+    }
+
+    #[test]
+    fn test_error_context_with_location() {
+        let err: Error = std::fs::File::open("non-existent-file")
+            .context_with_location("opening test file")
+            .unwrap_err();
+        assert!(matches!(err, Error::Context { .. }));
+        let msg = format!("{err}");
+        assert!(msg.contains("opening test file"));
+        assert!(msg.contains("non-existent-file") || msg.contains("No such"));
+        assert!(std::error::Error::source(&err).is_some());
+    }
 
     fn try_open_file() -> Result<()> {
         std::fs::File::open("non-existent-file")?;
         Ok(())
-    }
-
-    #[test]
-    fn test_error_location() {
-        try_open_file()
-            .map_err(|e| {
-                println!("Error: {e}");
-                e
-            })
-            .unwrap_err();
-        std::fs::File::open("non-existent-file")
-            .context("Failed to open file")
-            .unwrap_err();
     }
 }

--- a/rsproperties/src/lib.rs
+++ b/rsproperties/src/lib.rs
@@ -367,12 +367,17 @@ where
     T: std::str::FromStr,
     T::Err: std::fmt::Display,
 {
-    let value = try_system_properties()?.get_with_result(name)?;
-    value.parse().map_err(|e| {
-        Error::Parse(format!(
-            "Failed to parse '{value}' for property '{name}': {e}"
-        ))
-    })
+    // Route through `read_with` so the parse-and-discard path never
+    // allocates a `String` — the value bytes are handed to `FromStr` as
+    // `&str` borrowed from the seqlock buffer (short variant) or the mmap
+    // (long variant).
+    try_system_properties()?.read_with(name, |value| {
+        value.parse().map_err(|e| {
+            Error::Parse(format!(
+                "Failed to parse '{value}' for property '{name}': {e}"
+            ))
+        })
+    })?
 }
 
 /// Get a property value with default fallback
@@ -393,8 +398,17 @@ where
     let Ok(props) = try_system_properties() else {
         return default;
     };
-    match props.get_with_result(name) {
-        Ok(value) if !value.is_empty() => value.parse().unwrap_or(default),
+    // Two-stage closure: the inner `Result<T, T>` carries either the
+    // parsed value or the default back out of `read_with` without ever
+    // allocating a `String`. `Err(default)` is used to signal "use the
+    // default" because the callback can't capture-and-move it twice.
+    match props.read_with(name, |value| {
+        if value.is_empty() {
+            return Err(());
+        }
+        value.parse::<T>().map_err(|_| ())
+    }) {
+        Ok(Ok(v)) => v,
         _ => default,
     }
 }

--- a/rsproperties/src/lib.rs
+++ b/rsproperties/src/lib.rs
@@ -30,6 +30,12 @@
 //! }
 //! ```
 
+// Forward-compat with Rust 2024 edition: `unsafe fn` bodies must wrap
+// individual unsafe ops in their own `unsafe {}` blocks rather than
+// inheriting the function's effect. Enabling this lint as a warning today
+// keeps the codebase ready and surfaces regressions in PRs.
+#![warn(unsafe_op_in_unsafe_fn)]
+
 use std::{
     path::{Path, PathBuf},
     sync::OnceLock,
@@ -144,6 +150,7 @@ impl PropertyConfigBuilder {
 }
 
 pub mod errors;
+pub mod wire;
 pub use errors::{ContextWithLocation, Error, Result};
 
 #[cfg(feature = "builder")]
@@ -180,8 +187,9 @@ pub const PROP_DIRNAME: &str = "/dev/__properties__";
 
 // System properties directory.
 static SYSTEM_PROPERTIES_DIR: OnceLock<PathBuf> = OnceLock::new();
-// Global system properties.
-static SYSTEM_PROPERTIES: OnceLock<system_properties::SystemProperties> = OnceLock::new();
+// Global system properties. Stores Result so initialization failure does not
+// poison the OnceLock and callers can observe the error.
+static SYSTEM_PROPERTIES: OnceLock<Result<system_properties::SystemProperties>> = OnceLock::new();
 
 /// Initialize system properties with flexible configuration options.
 ///
@@ -207,64 +215,121 @@ static SYSTEM_PROPERTIES: OnceLock<system_properties::SystemProperties> = OnceLo
 /// init(config);
 /// ```
 pub fn init(config: PropertyConfig) {
-    // Initialize properties directory
+    // The `Result` form (`try_init`) is preferred for new code; this wrapper
+    // exists for backward compatibility and logs failures instead of returning
+    // them.
+    if let Err(e) = try_init(config) {
+        log::warn!("init: {e}");
+    }
+}
+
+/// Initialize system properties, returning an error when an option cannot be
+/// applied (typically because it was already set on a previous call).
+pub fn try_init(config: PropertyConfig) -> Result<()> {
     let props_dir = config.properties_dir.unwrap_or_else(|| {
         log::info!("Using default properties directory: {PROP_DIRNAME}");
         PathBuf::from(PROP_DIRNAME)
     });
 
-    match SYSTEM_PROPERTIES_DIR.set(props_dir.clone()) {
-        Ok(_) => {
-            log::info!("Successfully set system properties directory to: {props_dir:?}");
-        }
-        Err(_) => {
-            log::warn!("System properties directory already set, ignoring new value");
-        }
+    // Both `SYSTEM_PROPERTIES_DIR` and the socket-dir cell are first-write-
+    // wins. Pre-check both *before* committing either to avoid leaving the
+    // global state in a half-applied form (properties_dir locked, socket_dir
+    // unset) when the caller's intent was an atomic init.
+    if SYSTEM_PROPERTIES_DIR.get().is_some() {
+        return Err(Error::FileValidation(
+            "System properties directory already initialized".into(),
+        ));
+    }
+    if config.socket_dir.is_some() && system_property_set::socket_dir_is_set() {
+        return Err(Error::FileValidation(
+            "Socket directory already initialized".into(),
+        ));
     }
 
-    // Initialize socket directory if specified
+    SYSTEM_PROPERTIES_DIR.set(props_dir.clone()).map_err(|_| {
+        Error::FileValidation("System properties directory already initialized".into())
+    })?;
+    log::info!("Successfully set system properties directory to: {props_dir:?}");
+
     if let Some(socket_dir) = config.socket_dir {
-        let success = system_property_set::set_socket_dir(&socket_dir);
-        if success {
-            log::info!("Successfully set socket directory to: {socket_dir:?}");
-        } else {
-            log::warn!("Socket directory already set, ignoring new value");
+        if !system_property_set::set_socket_dir(&socket_dir) {
+            // Lost a race between the pre-check and the set; properties_dir
+            // is now committed but socket_dir is owned by another caller.
+            // Cannot un-set a `OnceLock`, so surface the inconsistency.
+            return Err(Error::FileValidation(
+                "Socket directory already initialized (race after pre-check)".into(),
+            ));
         }
+        log::info!("Successfully set socket directory to: {socket_dir:?}");
     }
+    Ok(())
 }
 
 /// Get the system properties directory.
 /// Returns the configured directory if init() was called,
 /// otherwise returns the default PROP_DIRNAME (/dev/__properties__).
 pub fn properties_dir() -> &'static Path {
-    let path = SYSTEM_PROPERTIES_DIR
+    SYSTEM_PROPERTIES_DIR
         .get_or_init(|| {
             log::info!("Using default properties directory: {PROP_DIRNAME}");
             PathBuf::from(PROP_DIRNAME)
         })
-        .as_path();
-    path
+        .as_path()
+}
+
+/// Get the system properties, returning an error if initialization fails.
+///
+/// This is the panic-free variant; `init()` should typically be called first
+/// to choose the properties directory. The initialization is cached, so
+/// subsequent calls reuse the same result (success or failure).
+pub fn try_system_properties() -> Result<&'static system_properties::SystemProperties> {
+    SYSTEM_PROPERTIES
+        .get_or_init(|| {
+            let dir = properties_dir();
+            log::debug!("Initializing global SystemProperties instance from: {dir:?}");
+
+            system_properties::SystemProperties::new(dir).inspect_err(|e| {
+                log::error!("Failed to initialize SystemProperties from {dir:?}: {e}");
+            })
+        })
+        .as_ref()
+        .map_err(|e| {
+            // We only have `&Error` from the cache, and `Error` isn't
+            // `Clone` (it transitively wraps `std::io::Error`). To avoid
+            // losing the failure context we walk `Error::source()` and
+            // flatten the chain into the Display string. Programmatic
+            // `source()` traversal is sacrificed here — preserving it
+            // would require caching `Arc<Error>` and changing the public
+            // return type.
+            Error::FileValidation(format_error_chain("SystemProperties init failed", e))
+        })
+}
+
+/// Formats `err` and its `source()` chain as `"<prefix>: <e0>: <e1>: ..."`.
+/// Used to surface root-cause info when we hold only `&Error` and can't
+/// build a `Error::Context` (which needs an owned source).
+fn format_error_chain(prefix: &str, err: &dyn std::error::Error) -> String {
+    use std::fmt::Write;
+    let mut out = format!("{prefix}: {err}");
+    let mut source = err.source();
+    while let Some(s) = source {
+        // ignore write! errors — String never fails to write
+        let _ = write!(&mut out, ": {s}");
+        source = s.source();
+    }
+    out
 }
 
 /// Get the system properties.
 /// Before calling this function, init() must be called.
 /// It panics if init() is not called or the system properties cannot be opened.
+///
+/// Prefer [`try_system_properties`] in code that must not panic.
 pub fn system_properties() -> &'static system_properties::SystemProperties {
-    SYSTEM_PROPERTIES.get_or_init(|| {
-        let dir = properties_dir();
-        log::debug!("Initializing global SystemProperties instance from: {dir:?}");
-
-        match system_properties::SystemProperties::new(dir) {
-            Ok(props) => {
-                log::debug!("Successfully initialized global SystemProperties instance");
-                props
-            }
-            Err(e) => {
-                log::error!("Failed to initialize SystemProperties from {dir:?}: {e}");
-                panic!("Failed to initialize SystemProperties from {dir:?}: {e}");
-            }
-        }
-    })
+    match try_system_properties() {
+        Ok(props) => props,
+        Err(e) => panic!("Failed to initialize SystemProperties: {e}"),
+    }
 }
 
 /// Aligns size to the specified alignment (bionic style)
@@ -302,7 +367,7 @@ where
     T: std::str::FromStr,
     T::Err: std::fmt::Display,
 {
-    let value = system_properties().get_with_result(name)?;
+    let value = try_system_properties()?.get_with_result(name)?;
     value.parse().map_err(|e| {
         Error::Parse(format!(
             "Failed to parse '{value}' for property '{name}': {e}"
@@ -323,9 +388,12 @@ where
 /// ```
 pub fn get_or<T>(name: &str, default: T) -> T
 where
-    T: std::str::FromStr + Clone,
+    T: std::str::FromStr,
 {
-    match system_properties().get_with_result(name) {
+    let Ok(props) = try_system_properties() else {
+        return default;
+    };
+    match props.get_with_result(name) {
         Ok(value) if !value.is_empty() => value.parse().unwrap_or(default),
         _ => default,
     }

--- a/rsproperties/src/property_area.rs
+++ b/rsproperties/src/property_area.rs
@@ -69,11 +69,7 @@ impl Debug for PropertyTrieNode {
 }
 
 fn cmp_prop_name(a: &[u8], b: &[u8]) -> std::cmp::Ordering {
-    match a.len().cmp(&b.len()) {
-        std::cmp::Ordering::Less => std::cmp::Ordering::Less,
-        std::cmp::Ordering::Greater => std::cmp::Ordering::Greater,
-        _ => a.cmp(b),
-    }
+    a.len().cmp(&b.len()).then_with(|| a.cmp(b))
 }
 
 #[derive(Debug)]
@@ -124,8 +120,7 @@ impl PropertyAreaMap {
             .create(true) // O_CREAT
             .custom_flags((fs::OFlags::NOFOLLOW.bits() | fs::OFlags::EXCL.bits()) as _) // additional flags
             .mode(0o444) // permission: 0444
-            .open(filename)
-            .map_err(Error::new_io)?;
+            .open(filename)?;
 
         if let Some(context) = context {
             if fs::fsetxattr(
@@ -167,7 +162,7 @@ impl PropertyAreaMap {
             .read(true) // read only
             .custom_flags(fs::OFlags::NOFOLLOW.bits() as _) // additional flags
             .open(filename)
-            .context_with_location("Failed to open to {filename:?}")?;
+            .context_with_location(format!("Failed to open {filename:?}"))?;
 
         let metadata = file
             .metadata()
@@ -191,14 +186,12 @@ impl PropertyAreaMap {
 
         let pa = thiz.property_area();
 
-        if thiz.property_area().magic != PROP_AREA_MAGIC
-            || thiz.property_area().version != PROP_AREA_VERSION
-        {
+        if pa.magic != PROP_AREA_MAGIC || pa.version != PROP_AREA_VERSION {
             error!(
                 "Invalid magic ({:#x} != {:#x}) or version ({:#x} != {:#x}) for {:?}",
                 pa.magic, PROP_AREA_MAGIC, pa.version, PROP_AREA_VERSION, filename
             );
-            Err(Error::new_file_validation(
+            Err(Error::FileValidation(
                 "Invalid magic or version".to_string(),
             ))
         } else {
@@ -234,17 +227,18 @@ impl PropertyAreaMap {
 
             if substr_size == 0 {
                 error!("Invalid property name (empty segment): '{name}'");
-                return Err(Error::new_parse(format!("Invalid property name: {name}")));
+                return Err(Error::Parse(format!("Invalid property name: {name}")));
             }
 
             let subname = &remaining_name[0..substr_size];
 
-            let children_offset = current.children.load(std::sync::atomic::Ordering::Relaxed);
-            let root = if children_offset != 0 {
-                self.to_prop_obj_from_atomic::<PropertyTrieNode>(&current.children)?
-            } else {
-                return Err(Error::new_not_found(name.to_owned()));
-            };
+            let children_offset = current.children.load(std::sync::atomic::Ordering::Acquire);
+            if children_offset == 0 {
+                return Err(Error::NotFound(name.to_owned()));
+            }
+            let root = self
+                .mmap
+                .to_object::<PropertyTrieNode>(children_offset as usize, self.data_offset)?;
 
             current = self.find_prop_trie_node(root, subname)?;
 
@@ -255,16 +249,15 @@ impl PropertyAreaMap {
             remaining_name = &remaining_name[substr_size + 1..];
         }
 
-        let prop_offset = current.prop.load(std::sync::atomic::Ordering::Relaxed);
-
+        let prop_offset = current.prop.load(std::sync::atomic::Ordering::Acquire);
         if prop_offset != 0 {
-            let offset = &current.prop.load(std::sync::atomic::Ordering::Acquire);
             Ok((
-                self.mmap.to_object(*offset as usize, self.data_offset)?,
-                *offset,
+                self.mmap
+                    .to_object(prop_offset as usize, self.data_offset)?,
+                prop_offset,
             ))
         } else {
-            Err(Error::new_not_found(name.to_owned()))
+            Err(Error::NotFound(name.to_owned()))
         }
     }
 
@@ -284,32 +277,22 @@ impl PropertyAreaMap {
 
             if substr_size == 0 {
                 error!("Invalid property name (empty segment): '{name}'");
-                return Err(Error::new_parse(format!("Invalid property name: {name}")));
+                return Err(Error::Parse(format!("Invalid property name: {name}")));
             }
 
             let subname = &remaining_name[0..substr_size];
 
-            let children_offset = {
-                let current_node = self
-                    .mmap
-                    .to_object::<PropertyTrieNode>(current, self.data_offset)?;
-                current_node
-                    .children
-                    .load(std::sync::atomic::Ordering::Relaxed)
-            };
+            let children_offset = self
+                .mmap
+                .to_object::<PropertyTrieNode>(current, self.data_offset)?
+                .children
+                .load(std::sync::atomic::Ordering::Acquire);
             let root_offset = if children_offset != 0 {
-                let current_node = self
-                    .mmap
-                    .to_object::<PropertyTrieNode>(current, self.data_offset)?;
-                current_node
-                    .children
-                    .load(std::sync::atomic::Ordering::Acquire)
+                children_offset
             } else {
                 let offset = self.new_prop_trie_node(subname)?;
-                let current_node = self
-                    .mmap
-                    .to_object::<PropertyTrieNode>(current, self.data_offset)?;
-                current_node
+                self.mmap
+                    .to_object::<PropertyTrieNode>(current, self.data_offset)?
                     .children
                     .store(offset, std::sync::atomic::Ordering::Release);
                 offset
@@ -324,12 +307,11 @@ impl PropertyAreaMap {
             remaining_name = &remaining_name[substr_size + 1..];
         }
 
-        let prop_offset = {
-            let current_node = self
-                .mmap
-                .to_object_mut::<PropertyTrieNode>(current, self.data_offset)?;
-            current_node.prop.load(std::sync::atomic::Ordering::Relaxed)
-        };
+        let prop_offset = self
+            .mmap
+            .to_object::<PropertyTrieNode>(current, self.data_offset)?
+            .prop
+            .load(std::sync::atomic::Ordering::Acquire);
 
         if prop_offset == 0 {
             let offset = self.new_prop_info(name, value)?;
@@ -358,23 +340,31 @@ impl PropertyAreaMap {
     // Set the dirty backup area.
     // It is used to store the backup of the property area.
     #[cfg(feature = "builder")]
-    pub(crate) fn set_dirty_backup_area(&mut self, value: &CStr) -> Result<()> {
+    pub(crate) fn set_dirty_backup_area(&mut self, value: &str) -> Result<()> {
         let offset = mem::size_of::<PropertyTrieNode>();
-        let bytes = value.to_bytes_with_nul();
-
-        if bytes.len() + offset > self.pa_data_size {
+        // Checked arithmetic so a wrapping `usize` doesn't bypass the size
+        // gate. Realistically `value.len()` is < PROP_VALUE_MAX (92), but
+        // this function is `pub(crate)` and the rest of the module uses
+        // `checked_*` throughout — keep the discipline.
+        let total_len = value.len().checked_add(1).ok_or_else(|| {
+            Error::FileValidation(format!("Backup value too long: {}", value.len()))
+        })?;
+        let end = total_len.checked_add(offset).ok_or_else(|| {
+            Error::FileValidation(format!(
+                "Backup area offset overflow: {total_len} + {offset}"
+            ))
+        })?;
+        if end > self.pa_data_size {
             error!(
-                "Backup area overflow: {} + {} > {}",
-                bytes.len(),
-                offset,
+                "Backup area overflow: {total_len} + {offset} > {}",
                 self.pa_data_size
             );
-            return Err(Error::new_file_validation("Invalid offset".to_string()));
+            return Err(Error::FileValidation("Invalid offset".to_string()));
         }
 
-        self.mmap
-            .data_mut(offset, self.data_offset, bytes.len())?
-            .copy_from_slice(bytes);
+        let dst = self.mmap.data_mut(offset, self.data_offset, total_len)?;
+        dst[..value.len()].copy_from_slice(value.as_bytes());
+        dst[value.len()] = 0;
         Ok(())
     }
 
@@ -389,53 +379,34 @@ impl PropertyAreaMap {
                 .mmap
                 .to_object::<PropertyTrieNode>(current_offset as usize, self.data_offset)?;
 
-            match cmp_prop_name(name_bytes, current_node.name()?.to_bytes()) {
+            let ordering = cmp_prop_name(name_bytes, current_node.name()?.to_bytes());
+            let child_offset = match ordering {
                 std::cmp::Ordering::Less => {
-                    let left_offset = current_node.left.load(std::sync::atomic::Ordering::Relaxed);
-                    if left_offset != 0 {
-                        current_offset =
-                            current_node.left.load(std::sync::atomic::Ordering::Acquire);
-                    } else {
-                        let offset = self.new_prop_trie_node(name)?;
-
-                        // To avoid the life time issue of current trie node.
-                        let current_node = self.mmap.to_object::<PropertyTrieNode>(
-                            current_offset as usize,
-                            self.data_offset,
-                        )?;
-                        current_node
-                            .left
-                            .store(offset, std::sync::atomic::Ordering::Release);
-                        current_offset = offset;
-                        break;
-                    }
+                    current_node.left.load(std::sync::atomic::Ordering::Acquire)
                 }
-                std::cmp::Ordering::Greater => {
-                    let right_offset = current_node
-                        .right
-                        .load(std::sync::atomic::Ordering::Relaxed);
-                    if right_offset != 0 {
-                        current_offset = current_node
-                            .right
-                            .load(std::sync::atomic::Ordering::Acquire);
-                    } else {
-                        let offset = self.new_prop_trie_node(name)?;
-                        // To avoid the life time issue of current trie node.
-                        let current_node = self.mmap.to_object::<PropertyTrieNode>(
-                            current_offset as usize,
-                            self.data_offset,
-                        )?;
-                        current_node
-                            .right
-                            .store(offset, std::sync::atomic::Ordering::Release);
-                        current_offset = offset;
-                        break;
-                    }
-                }
-                std::cmp::Ordering::Equal => {
-                    break;
-                }
+                std::cmp::Ordering::Greater => current_node
+                    .right
+                    .load(std::sync::atomic::Ordering::Acquire),
+                std::cmp::Ordering::Equal => break,
+            };
+            if child_offset != 0 {
+                current_offset = child_offset;
+                continue;
             }
+            // Empty slot — allocate the new node, then re-borrow to store the
+            // link (Release) before exiting the loop.
+            let offset = self.new_prop_trie_node(name)?;
+            let current_node = self
+                .mmap
+                .to_object::<PropertyTrieNode>(current_offset as usize, self.data_offset)?;
+            let link = match ordering {
+                std::cmp::Ordering::Less => &current_node.left,
+                std::cmp::Ordering::Greater => &current_node.right,
+                std::cmp::Ordering::Equal => unreachable!(),
+            };
+            link.store(offset, std::sync::atomic::Ordering::Release);
+            current_offset = offset;
+            break;
         }
         Ok(current_offset)
     }
@@ -448,29 +419,19 @@ impl PropertyAreaMap {
         let name_bytes = name.as_bytes();
         let mut current = trie;
         loop {
-            match cmp_prop_name(name_bytes, current.name()?.to_bytes()) {
-                std::cmp::Ordering::Less => {
-                    let left_offset = current.left.load(std::sync::atomic::Ordering::Relaxed);
-                    if left_offset != 0 {
-                        current =
-                            self.to_prop_obj_from_atomic::<PropertyTrieNode>(&current.left)?;
-                    } else {
-                        return Err(Error::new_not_found(name.to_owned()));
-                    }
-                }
+            let next_offset = match cmp_prop_name(name_bytes, current.name()?.to_bytes()) {
+                std::cmp::Ordering::Less => current.left.load(std::sync::atomic::Ordering::Acquire),
                 std::cmp::Ordering::Greater => {
-                    let right_offset = current.right.load(std::sync::atomic::Ordering::Relaxed);
-                    if right_offset != 0 {
-                        current =
-                            self.to_prop_obj_from_atomic::<PropertyTrieNode>(&current.right)?;
-                    } else {
-                        return Err(Error::new_not_found(name.to_owned()));
-                    }
+                    current.right.load(std::sync::atomic::Ordering::Acquire)
                 }
-                std::cmp::Ordering::Equal => {
-                    break;
-                }
+                std::cmp::Ordering::Equal => break,
+            };
+            if next_offset == 0 {
+                return Err(Error::NotFound(name.to_owned()));
             }
+            current = self
+                .mmap
+                .to_object::<PropertyTrieNode>(next_offset as usize, self.data_offset)?;
         }
         Ok(current)
     }
@@ -482,12 +443,12 @@ impl PropertyAreaMap {
 
         // Convert aligned to u32 with overflow check
         let aligned_u32 = u32::try_from(aligned).map_err(|_| {
-            Error::new_file_size(format!("Aligned size too large to fit in u32: {}", aligned))
+            Error::FileSize(format!("Aligned size too large to fit in u32: {}", aligned))
         })?;
 
         // checked_add to prevent overflow
         let new_offset = offset.checked_add(aligned_u32).ok_or_else(|| {
-            Error::new_file_size(format!(
+            Error::FileSize(format!(
                 "Offset overflow: {} + {} would exceed u32::MAX",
                 offset, aligned_u32
             ))
@@ -499,7 +460,7 @@ impl PropertyAreaMap {
                 "Out of memory: new_offset={} > pa_data_size={}",
                 new_offset, self.pa_data_size
             );
-            return Err(Error::new_file_size(format!(
+            return Err(Error::FileSize(format!(
                 "Out of memory: {} + {} = {} > {}",
                 offset, aligned_u32, new_offset, self.pa_data_size
             )));
@@ -549,13 +510,35 @@ impl PropertyAreaMap {
         Ok(new_offset)
     }
 
-    fn to_prop_obj_from_atomic<T>(&self, offset: &AtomicU32) -> Result<&T> {
-        let offset = offset.load(std::sync::atomic::Ordering::Acquire);
+    pub(crate) fn property_info(&self, offset: u32) -> Result<&PropertyInfo> {
         self.mmap.to_object(offset as usize, self.data_offset)
     }
 
-    pub(crate) fn property_info(&self, offset: u32) -> Result<&PropertyInfo> {
-        self.mmap.to_object(offset as usize, self.data_offset)
+    /// Returns a `&mut PropertyInfo` for the entry at `offset`. Exposed only
+    /// to the builder feature because the in-place update path is the only
+    /// caller; together with `&mut PropertyAreaMap` it enforces single-writer
+    /// inside one process via the borrow checker.
+    #[cfg(feature = "builder")]
+    pub(crate) fn property_info_mut(&mut self, offset: u32) -> Result<&mut PropertyInfo> {
+        self.mmap.to_object_mut(offset as usize, self.data_offset)
+    }
+
+    /// Computes the maximum number of bytes that may be safely scanned past
+    /// `pi` without leaving this mmap. Returned to callers that need to read
+    /// long-property values whose length is not encoded in the header.
+    pub(crate) fn max_value_bound(&self, pi: &PropertyInfo) -> usize {
+        let pi_addr = pi as *const _ as usize;
+        let mmap_start = self.mmap.data as usize;
+        let mmap_end = mmap_start.saturating_add(self.mmap.size);
+        // Require room for the header AND at least one trailing byte (the
+        // NUL terminator slot). Without the `+ 1`, `pi_addr + header ==
+        // mmap_end` would return `header` and let `PropertyInfo::name` scan
+        // a single byte past the mapping.
+        let header = std::mem::size_of::<PropertyInfo>();
+        if pi_addr < mmap_start || pi_addr.saturating_add(header + 1) > mmap_end {
+            return 0;
+        }
+        mmap_end - pi_addr
     }
 }
 
@@ -567,21 +550,29 @@ pub(crate) struct MemoryMap {
     size: usize,
 }
 
-// SAFETY: MemoryMap is safe to send between threads because:
-// - The underlying memory mapping is thread-safe at the OS level
-// - All access to the mapped memory goes through atomic operations or proper synchronization
-// - The File handle doesn't need to be accessed after mapping
+// SAFETY: The `data` pointer is owned by this MemoryMap and remains valid for
+// `size` bytes until `Drop` calls `munmap`. The pointer itself is not mutated
+// after construction. Higher-level invariants for the contents of the mapped
+// region (atomic vs non-atomic writes) are the responsibility of the callers
+// in this module — for shared writable mappings, the builder phase is expected
+// to complete before any readers attach.
 unsafe impl Send for MemoryMap {}
 
-// SAFETY: MemoryMap is safe to share between threads because:
-// - Memory-mapped regions can be safely accessed from multiple threads
-// - All property operations use atomic reads/writes or are properly synchronized
-// - The data pointer is immutable after initialization
+// SAFETY: See `Send` above. Concurrent readers via `&self` only touch atomic
+// fields exposed through `to_object`. Mutations via `&mut self` are exclusive
+// by Rust's borrow rules. For mmaps shared across processes, the same
+// builder-phase precondition documented on `Send` applies.
 unsafe impl Sync for MemoryMap {}
 
 impl MemoryMap {
     pub(crate) fn new(file: File, size: usize, writable: bool) -> Result<Self> {
         debug!("Creating memory map: size={size}, writable={writable}");
+
+        if size == 0 {
+            return Err(Error::FileValidation(
+                "Cannot mmap zero-sized region".into(),
+            ));
+        }
 
         let flags = if writable {
             mm::ProtFlags::READ.union(mm::ProtFlags::WRITE)
@@ -589,6 +580,8 @@ impl MemoryMap {
             mm::ProtFlags::READ
         };
 
+        // SAFETY: `file` is a valid owned `File`, `size > 0` is checked above,
+        // and `mm::mmap` reports failure via `Result` rather than `MAP_FAILED`.
         let memory_area = unsafe {
             mm::mmap(
                 std::ptr::null_mut(),
@@ -612,8 +605,11 @@ impl MemoryMap {
     }
 
     pub(crate) fn data(&self, offset: usize, base: usize, size: usize) -> Result<&[u8]> {
-        let offset = offset + base;
+        let offset = self.checked_offset(offset, base)?;
         self.check_size(offset, size)?;
+        // SAFETY: `offset + size <= self.size`, so the resulting slice lies
+        // entirely within the mmap region. `u8` has no alignment requirement.
+        // Lifetime is tied to `&self`, matching the mmap's lifetime.
         Ok(unsafe { std::slice::from_raw_parts(self.data.add(offset) as *const u8, size) })
     }
 
@@ -624,22 +620,50 @@ impl MemoryMap {
         base: usize,
         size: usize,
     ) -> Result<&mut [u8]> {
-        let offset = offset + base;
+        let offset = self.checked_offset(offset, base)?;
         self.check_size(offset, size)?;
-
+        // SAFETY: `offset + size <= self.size`. `&mut self` ensures exclusive
+        // access to the mmap region. `u8` has no alignment requirement.
         Ok(unsafe { std::slice::from_raw_parts_mut(self.data.add(offset), size) })
     }
 
+    /// Returns `offset + base` after verifying neither the addition nor the
+    /// final value overflow `usize`. Wrapping behavior in release builds would
+    /// otherwise let later bounds checks be silently bypassed.
+    fn checked_offset(&self, offset: usize, base: usize) -> Result<usize> {
+        offset
+            .checked_add(base)
+            .ok_or_else(|| Error::FileValidation(format!("Offset overflow: {offset} + {base}")))
+    }
+
     fn check_size(&self, offset: usize, size: usize) -> Result<()> {
-        if offset + size > self.size {
+        let end = offset
+            .checked_add(size)
+            .ok_or_else(|| Error::FileValidation(format!("Size overflow: {offset} + {size}")))?;
+        if end > self.size {
             error!(
                 "Memory access out of bounds: {} + {} > {} (ptr={:p})",
                 offset, size, self.size, self.data
             );
-            return Err(Error::new_file_validation(format!(
-                "Invalid offset: {} > {}",
-                offset + size,
+            return Err(Error::FileValidation(format!(
+                "Invalid offset: {end} > {}",
                 self.size
+            )));
+        }
+        Ok(())
+    }
+
+    /// Verifies that `self.data.add(offset)` produces a pointer with the
+    /// required alignment for `T`. The mmap base is page-aligned, so this
+    /// reduces to a check on `offset % align_of::<T>()`.
+    fn check_alignment<T>(&self, offset: usize) -> Result<()> {
+        let align = mem::align_of::<T>();
+        // SAFETY: `add(offset)` is only used to compute the address, not
+        // dereferenced here. `offset <= self.size` is verified by the caller.
+        let ptr_addr = unsafe { self.data.add(offset) } as usize;
+        if ptr_addr % align != 0 {
+            return Err(Error::FileValidation(format!(
+                "Misaligned object at offset {offset}: required align={align}, addr={ptr_addr:#x}"
             )));
         }
         Ok(())
@@ -649,31 +673,44 @@ impl MemoryMap {
     // base is the base offset of the object.
     // offset is calculated by adding the base offset and the given offset.
     pub(crate) fn to_object<T>(&self, offset: usize, base: usize) -> Result<&T> {
-        let offset = offset + base;
+        let offset = self.checked_offset(offset, base)?;
         self.check_size(offset, mem::size_of::<T>())?;
-        Ok(unsafe { &*(self.data.add(offset as _) as *const T) })
+        self.check_alignment::<T>(offset)?;
+        // SAFETY: bounds and alignment are both verified above. The resulting
+        // reference's lifetime is tied to `&self`, which owns the mmap.
+        Ok(unsafe { &*(self.data.add(offset) as *const T) })
     }
 
     // Convert the memory-mapped file to the mutable object with the given offset.
     pub(crate) fn to_object_mut<T>(&mut self, offset: usize, base: usize) -> Result<&mut T> {
-        let offset = offset + base;
+        let offset = self.checked_offset(offset, base)?;
         self.check_size(offset, mem::size_of::<T>())?;
+        self.check_alignment::<T>(offset)?;
+        // SAFETY: bounds and alignment are both verified above. `&mut self`
+        // ensures exclusive access for the lifetime of the returned reference.
         Ok(unsafe { &mut *(self.data.add(offset) as *mut T) })
     }
 
     // Convert the memory-mapped file to the CStr with the given offset.
     pub(crate) fn to_cstr(&self, offset: usize, base: usize) -> Result<&CStr> {
-        let offset = offset + base;
-        self.check_size(offset, 1)?;
-        unsafe {
-            let ptr = self.data.add(offset) as *const _;
-            Ok(CStr::from_ptr(ptr))
-        }
+        let offset = self.checked_offset(offset, base)?;
+        // Bound the NUL scan to the remaining mmap; `CStr::from_ptr` would
+        // otherwise read past the mapping if no terminator is present.
+        let remaining = self.size.checked_sub(offset).ok_or_else(|| {
+            Error::FileValidation(format!("Offset past mmap: {offset} > {}", self.size))
+        })?;
+        // SAFETY: bounds checked above; `u8` has no alignment requirement.
+        let bytes = unsafe { std::slice::from_raw_parts(self.data.add(offset), remaining) };
+        CStr::from_bytes_until_nul(bytes).map_err(|e| {
+            Error::FileValidation(format!("No NUL terminator at offset {offset}: {e}"))
+        })
     }
 }
 
 impl std::ops::Drop for MemoryMap {
     fn drop(&mut self) {
+        // SAFETY: `self.data` was returned by `mm::mmap` with `self.size`
+        // bytes in `MemoryMap::new` and has not been unmapped since.
         unsafe {
             if let Err(e) = mm::munmap(self.data as _, self.size) {
                 error!("Failed to unmap memory: {e:?}");

--- a/rsproperties/src/property_area.rs
+++ b/rsproperties/src/property_area.rs
@@ -339,8 +339,14 @@ impl PropertyAreaMap {
 
     // Set the dirty backup area.
     // It is used to store the backup of the property area.
+    //
+    // Accepts raw bytes (not `&str`) so the caller can stream the current
+    // property value directly from the byte-atomic mmap slot into the
+    // backup area without first materialising a `String`. The reader side
+    // already validates UTF-8 after the seqlock re-check, so the backup
+    // area itself stores raw bytes verbatim.
     #[cfg(feature = "builder")]
-    pub(crate) fn set_dirty_backup_area(&mut self, value: &str) -> Result<()> {
+    pub(crate) fn set_dirty_backup_area(&mut self, value: &[u8]) -> Result<()> {
         let offset = mem::size_of::<PropertyTrieNode>();
         // Checked arithmetic so a wrapping `usize` doesn't bypass the size
         // gate. Realistically `value.len()` is < PROP_VALUE_MAX (92), but
@@ -363,7 +369,7 @@ impl PropertyAreaMap {
         }
 
         let dst = self.mmap.data_mut(offset, self.data_offset, total_len)?;
-        dst[..value.len()].copy_from_slice(value.as_bytes());
+        dst[..value.len()].copy_from_slice(value);
         dst[value.len()] = 0;
         Ok(())
     }

--- a/rsproperties/src/property_info.rs
+++ b/rsproperties/src/property_info.rs
@@ -1,195 +1,383 @@
 // Copyright 2024 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(feature = "builder")]
-use log::warn;
+//! Per-property entries in the mmap'd property area.
+//!
+//! # Concurrency model
+//!
+//! - `serial` is the seqlock that synchronizes reader/writer races. Readers
+//!   load it Acquire before and after a value read; on mismatch they retry.
+//! - `data` is byte-wise atomic ([`AtomicU8`] array). Writers mutate via
+//!   [`PropertyInfoWriter`] which requires `&mut self` (the borrow checker
+//!   enforces single-writer within a process).
+//! - **Cross-process invariant.** Multi-process mmap sharing requires a
+//!   system-level single-writer policy (e.g. Android `init` owns the writable
+//!   mapping). This crate cannot enforce that policy from Rust; the
+//!   `unsafe impl Sync` below documents the assumption.
+
+use std::cell::UnsafeCell;
 use std::ffi::CStr;
 use std::mem;
 #[cfg(feature = "builder")]
 use std::ptr;
-use std::sync::atomic::AtomicU32;
+use std::sync::atomic::{AtomicU32, AtomicU8, Ordering};
 
+use crate::errors::{Error, Result};
 use crate::system_properties::PROP_VALUE_MAX;
 
 #[cfg(feature = "builder")]
 const LONG_LEGACY_ERROR: &str = "Must use __system_property_read_callback() to read";
 
-const LONG_FLAG: usize = 1 << 16;
+const LONG_FLAG: u32 = 1 << 16;
 const LONG_LEGACY_ERROR_BUFFER_SIZE: usize = 56;
+
+// `AtomicU8` / `AtomicU32` are guaranteed by `std::sync::atomic` to have the
+// same in-memory representation and alignment as `u8` / `u32`. Asserting it
+// here keeps the on-disk mmap layout — shared with native bionic property
+// files — byte-compatible.
+const _: () = assert!(mem::size_of::<AtomicU8>() == mem::size_of::<u8>());
+const _: () = assert!(mem::align_of::<AtomicU8>() == mem::align_of::<u8>());
+const _: () = assert!(mem::size_of::<AtomicU32>() == mem::size_of::<u32>());
+const _: () = assert!(mem::align_of::<AtomicU32>() == mem::align_of::<u32>());
+const _: () = assert!(mem::size_of::<[AtomicU8; PROP_VALUE_MAX]>() == PROP_VALUE_MAX);
 
 #[repr(C)]
 struct LongProperty {
     error_message: [u8; LONG_LEGACY_ERROR_BUFFER_SIZE],
-    offset: u32,
+    offset: AtomicU32,
 }
 
 #[repr(C)]
 union Union {
-    value: [u8; PROP_VALUE_MAX],
-    long_property: std::mem::ManuallyDrop<LongProperty>,
+    value: mem::ManuallyDrop<[AtomicU8; PROP_VALUE_MAX]>,
+    long_property: mem::ManuallyDrop<LongProperty>,
 }
 
 #[repr(C, align(4))]
 pub struct PropertyInfo {
     pub(crate) serial: AtomicU32,
-    data: Union,
+    data: UnsafeCell<Union>,
 }
+
+// SAFETY: All writes to `data` go through `PropertyInfoWriter`, which holds
+// `&mut PropertyInfo` — the borrow checker enforces a single in-process
+// writer. All reader-visible memory is byte-wise atomic, so concurrent
+// reads against an in-flight writer are well-defined (no torn-byte UB under
+// the Rust abstract machine). Cross-process mmap sharing requires a
+// system-level single-writer policy; see module-level docs.
+unsafe impl Sync for PropertyInfo {}
 
 impl PropertyInfo {
     #[cfg(feature = "builder")]
     pub(crate) fn init_with_long_offset(&mut self, name: &str, offset: u32) {
         init_name_with_trailing_data(self, name);
         let error_bytes = LONG_LEGACY_ERROR.as_bytes();
-        let error_value_len = error_bytes.len();
-        let serial_value = ((error_value_len << 24) | LONG_FLAG) as u32;
+        let serial_value = ((error_bytes.len() as u32) << 24) | LONG_FLAG;
 
-        self.serial
-            .store(serial_value, std::sync::atomic::Ordering::Relaxed);
+        self.serial.store(serial_value, Ordering::Relaxed);
 
+        // SAFETY: `&mut self` grants exclusive access; the union variant we
+        // write (`long_property`) matches what `value()` reads when the LONG
+        // flag is set in `serial`. `get_mut()` on the atomic is the no-fence
+        // assignment appropriate for init time (no concurrent readers).
         unsafe {
-            let long_property = &mut self.data.long_property;
-
-            // Calculate copy length - simply take minimum of source and destination
-            let copy_len = error_bytes.len().min(long_property.error_message.len());
-
-            // Copy error message
-            long_property.error_message[..copy_len].copy_from_slice(&error_bytes[..copy_len]);
-
-            // Zero-fill remaining space
-            long_property.error_message[copy_len..].fill(0);
-
-            // Set offset
-            long_property.offset = offset;
+            let long_property = &mut *(*self.data.get()).long_property;
+            long_property.error_message =
+                error_bytes_padded::<LONG_LEGACY_ERROR_BUFFER_SIZE>(error_bytes);
+            *long_property.offset.get_mut() = offset;
         }
     }
 
     #[cfg(feature = "builder")]
     pub(crate) fn init_with_value(&mut self, name: &str, value: &str) {
         init_name_with_trailing_data(self, name);
-        let serial_value = (value.len() << 24) as u32;
+        let serial_value = (value.len() as u32) << 24;
+        self.serial.store(serial_value, Ordering::Relaxed);
 
-        self.serial
-            .store(serial_value, std::sync::atomic::Ordering::Relaxed);
-
-        // Safe memory copy with bounds checking
+        // SAFETY: `&mut self` grants exclusive access; we initialize the
+        // `value` variant of the union to match the non-LONG `serial` state.
         unsafe {
-            let value_bytes = value.as_bytes();
-            let max_len = PROP_VALUE_MAX.saturating_sub(1); // Reserve space for null terminator
-            let copy_len = value_bytes.len().min(max_len);
-
-            let dest_slice = &mut self.data.value[..copy_len];
-            dest_slice.copy_from_slice(&value_bytes[..copy_len]);
-
-            // Add null terminator
-            if copy_len < PROP_VALUE_MAX {
-                self.data.value[copy_len] = 0;
-            }
+            let slot = &mut *(*self.data.get()).value;
+            init_value_bytes(slot, value.as_bytes());
         }
     }
-    /*
-        pub(crate) fn set_name(&mut self, name: &str) {
-            unsafe {
-                let self_ptr = self as *mut _ as *mut u8;
-                let name_ptr = self_ptr.add(mem::size_of::<Self>()) as *mut u8;
-                ptr::copy_nonoverlapping(name.as_ptr(), name_ptr, name.len());
-                *name_ptr.add(name.len()) = 0; // Add null terminator
-            }
+
+    /// Reads the trailing name field.
+    ///
+    /// `bound` caps the NUL scan at the remaining mmap extent past `self`,
+    /// computed by the enclosing `PropertyAreaMap` via `max_value_bound`.
+    pub(crate) fn name(&self, bound: usize) -> Result<&CStr> {
+        let header = mem::size_of::<PropertyInfo>();
+        // `name_from_trailing_data` reads `len + 1` bytes; bail out when the
+        // bound is too small to even hold the NUL terminator. Paired with
+        // `PropertyAreaMap::max_value_bound`, which already rejects entries
+        // whose trailing region is < 1 byte by returning 0.
+        if bound <= header {
+            return Err(Error::Encoding(
+                "PropertyInfo name has no room for terminator".into(),
+            ));
         }
-    */
-    pub(crate) fn name(&self) -> crate::errors::Result<&CStr> {
-        name_from_trailing_data(self, None)
+        let len = bound - header - 1;
+        name_from_trailing_data(self, Some(len))
     }
 
-    pub(crate) fn value(&self) -> crate::errors::Result<&CStr> {
+    /// Reads the property value as raw bytes (no UTF-8 validation).
+    ///
+    /// Returning bytes lets the seqlock read loop validate the serial
+    /// *before* attempting UTF-8 decoding. With byte-wise atomic stores a
+    /// reader may observe partially-written multi-byte sequences that
+    /// would otherwise spuriously fail `String::from_utf8` and abort the
+    /// retry loop. Callers that need a `String` should validate the
+    /// serial first, then call [`Self::value_as_string`] or convert
+    /// directly via `String::from_utf8`.
+    ///
+    /// `long_value_bound` is an upper bound on how far past `self` the
+    /// long variant may extend. For the short variant this argument is
+    /// ignored.
+    /// Reads short-variant bytes into `buf` (no allocation); returns the
+    /// populated prefix. The long variant still allocates because its data
+    /// lives out-of-line in the mmap and a stack buffer can't bound its
+    /// length statically.
+    pub(crate) fn value_bytes<'a>(
+        &self,
+        long_value_bound: usize,
+        buf: &'a mut [u8; PROP_VALUE_MAX],
+    ) -> Result<std::borrow::Cow<'a, [u8]>> {
         if self.is_long() {
-            unsafe {
-                let long_property = &self.data.long_property;
-                let self_ptr = self as *const _ as *const u8;
-                let value_ptr = self_ptr.add(long_property.offset as usize) as *const i8;
-
-                // Don't know the length of the long property value, so it depends on the null terminator.
-                Ok(CStr::from_ptr(value_ptr as _))
-            }
+            // SAFETY: when the LONG flag is set the union variant is
+            // `long_property`. The offset is read atomically; the
+            // out-of-line value is bounded by `long_value_bound`.
+            let bytes = unsafe {
+                let long_property = &*(*self.data.get()).long_property;
+                let offset = long_property.offset.load(Ordering::Relaxed) as usize;
+                long_value_bytes(self, offset, long_value_bound)?
+            };
+            Ok(std::borrow::Cow::Owned(bytes))
         } else {
+            // SAFETY: when the LONG flag is clear the union variant is the
+            // byte-wise atomic `value` array of size `PROP_VALUE_MAX`.
             unsafe {
-                let value_ptr = self.data.value.as_ptr() as _;
-                // The length of the property value is limited to PROP_VALUE_MAX, so we can safely convert it to CStr.
-                CStr::from_bytes_until_nul(std::slice::from_raw_parts(value_ptr, PROP_VALUE_MAX))
-                    .map_err(|e| {
-                        crate::errors::Error::new_encoding(format!(
-                            "Failed to convert property value to CStr: {e}"
-                        ))
-                    })
+                let slot = &*(*self.data.get()).value;
+                Ok(std::borrow::Cow::Borrowed(read_value_atomic(slot, buf)))
             }
         }
     }
 
-    // TODO: self must be mutable. The current implementation is a workaround.
-    #[cfg(feature = "builder")]
-    pub(crate) fn set_value(&self, value: &str) {
-        if self.is_long() {
-            warn!("Attempting to set value on long property - this may not work correctly");
-        }
-
-        // Safe memory copy with bounds checking
-        unsafe {
-            let value_bytes = value.as_bytes();
-            let max_len = PROP_VALUE_MAX.saturating_sub(1); // Reserve space for null terminator
-            let copy_len = value_bytes.len().min(max_len);
-
-            let dest_ptr = self.data.value.as_ptr() as *mut u8;
-            let dest_slice = std::slice::from_raw_parts_mut(dest_ptr, copy_len);
-            dest_slice.copy_from_slice(&value_bytes[..copy_len]);
-
-            // Add null terminator
-            if copy_len < PROP_VALUE_MAX {
-                *dest_ptr.add(copy_len) = 0;
-            }
-        }
+    /// Convenience: reads the value AND validates UTF-8 in one step. Use
+    /// only outside the seqlock read loop — for retry-friendly reads, call
+    /// [`Self::value_bytes`] and validate after the serial re-check.
+    pub(crate) fn value(&self, long_value_bound: usize) -> Result<String> {
+        let mut buf = [0u8; PROP_VALUE_MAX];
+        let bytes = self.value_bytes(long_value_bound, &mut buf)?;
+        std::str::from_utf8(&bytes)
+            .map(str::to_owned)
+            .map_err(|e| Error::Encoding(format!("property value is not valid UTF-8: {e}")))
     }
 
     pub(crate) fn is_long(&self) -> bool {
-        let serial = self.serial.load(std::sync::atomic::Ordering::Relaxed);
-        serial & (LONG_FLAG as u32) != 0
+        let serial = self.serial.load(Ordering::Relaxed);
+        serial & LONG_FLAG != 0
+    }
+
+    /// Returns a writer that has exclusive update rights to this entry.
+    ///
+    /// `&mut self` ensures only one writer exists within a process; the
+    /// returned writer enforces the seqlock + LONG-flag invariants.
+    /// Cross-process invariants are documented at the module level.
+    #[cfg(feature = "builder")]
+    pub(crate) fn writer(&mut self) -> PropertyInfoWriter<'_> {
+        PropertyInfoWriter(self)
     }
 }
 
+/// Single-writer handle. Construction requires `&mut PropertyInfo`, so the
+/// borrow checker enforces one-writer-per-process. All publish operations
+/// use `Ordering::Release` so paired Acquire readers see the value writes.
+#[cfg(feature = "builder")]
+pub(crate) struct PropertyInfoWriter<'a>(&'a mut PropertyInfo);
+
+/// Counter bits in `serial` — bits 0..24 excluding `LONG_FLAG` (bit 16).
+/// Using a wider mask would let the counter wrap into the LONG_FLAG bit and
+/// silently flip the union variant under readers.
+#[cfg(feature = "builder")]
+const SERIAL_COUNTER_MASK: u32 = 0x00ff_ffff & !LONG_FLAG;
+
+#[cfg(feature = "builder")]
+impl PropertyInfoWriter<'_> {
+    /// Atomic short-value update: validate → set dirty → write bytes →
+    /// publish new serial. Returns the published serial.
+    ///
+    /// The entire seqlock protocol is encapsulated here so callers cannot
+    /// leave the entry in a half-published state: every failure path occurs
+    /// *before* `set_dirty`, and once the dirty bit is published the
+    /// remaining steps are infallible (byte-wise atomic stores + atomic
+    /// serial publish).
+    ///
+    /// Rejects when the LONG flag is set — switching the union variant
+    /// in-place would leak the out-of-line long-property buffer.
+    pub(crate) fn apply_write(self, value: &str) -> Result<u32> {
+        let current = self.0.serial.load(Ordering::Relaxed);
+        if current & LONG_FLAG != 0 {
+            return Err(Error::FileValidation(format!(
+                "in-place update of long property is not supported (serial={current:#x})"
+            )));
+        }
+        let len_u32 = u32::try_from(value.len()).map_err(|_| {
+            Error::FileValidation(format!("Value length exceeds u32: {}", value.len()))
+        })?;
+        if value.len() >= PROP_VALUE_MAX {
+            return Err(Error::FileValidation(format!(
+                "Value too long: {} (max: {})",
+                value.len(),
+                PROP_VALUE_MAX
+            )));
+        }
+
+        // bionic seqlock convention: even serial = clean, odd = dirty. We
+        // first publish `current | 1` (dirty), then `(dirty + 1)` carries
+        // the LSB back to 0 (clean) while bumping the counter. The counter
+        // mask excludes LONG_FLAG so a long-lived short property cannot
+        // wrap into the LONG variant.
+        let dirty_serial = current | 1;
+        let counter_next = (dirty_serial.wrapping_add(1)) & SERIAL_COUNTER_MASK;
+        let new_serial = (len_u32 << 24) | counter_next;
+
+        // From here on no further early returns: each step is infallible.
+        self.0.serial.store(dirty_serial, Ordering::Release);
+        // SAFETY: `&mut self` on the writer guarantees no concurrent writer
+        // in this process; the LONG flag check above confirms the active
+        // variant is `value`. Byte-wise atomic stores keep concurrent
+        // readers race-free per the Rust memory model.
+        unsafe {
+            let slot = &*(*self.0.data.get()).value;
+            write_value_atomic(slot, value.as_bytes());
+        }
+        self.0.serial.store(new_serial, Ordering::Release);
+        Ok(new_serial)
+    }
+}
+
+#[cfg(feature = "builder")]
+fn error_bytes_padded<const N: usize>(src: &[u8]) -> [u8; N] {
+    let mut buf = [0u8; N];
+    let copy_len = src.len().min(N);
+    buf[..copy_len].copy_from_slice(&src[..copy_len]);
+    buf
+}
+
+/// Reads bytes from `slot` into `buf` until the first NUL or `PROP_VALUE_MAX`
+/// bytes, byte-wise with `Relaxed` ordering. Returns the populated prefix
+/// (excluding the NUL terminator).
+///
+/// Uses a caller-provided stack buffer instead of allocating a `Vec` so the
+/// seqlock retry loop in `read_mutable_property_value` doesn't allocate on
+/// every iteration. The caller materialises an owned value only once, after
+/// the serial re-check confirms the read was consistent.
+fn read_value_atomic<'a>(
+    slot: &[AtomicU8; PROP_VALUE_MAX],
+    buf: &'a mut [u8; PROP_VALUE_MAX],
+) -> &'a [u8] {
+    let mut len = 0;
+    for (i, cell) in slot.iter().enumerate() {
+        let b = cell.load(Ordering::Relaxed);
+        if b == 0 {
+            break;
+        }
+        buf[i] = b;
+        len = i + 1;
+    }
+    &buf[..len]
+}
+
+/// Byte-wise atomic write. Truncates to `PROP_VALUE_MAX - 1`, then writes a
+/// NUL terminator. Caller is responsible for the surrounding seqlock fences
+/// (Release stores on `serial`).
+#[cfg(feature = "builder")]
+fn write_value_atomic(slot: &[AtomicU8; PROP_VALUE_MAX], bytes: &[u8]) {
+    let copy_len = bytes.len().min(PROP_VALUE_MAX - 1);
+    for (i, &b) in bytes[..copy_len].iter().enumerate() {
+        slot[i].store(b, Ordering::Relaxed);
+    }
+    slot[copy_len].store(0, Ordering::Relaxed);
+}
+
+/// Init-only variant for `init_with_value`. Uses `get_mut()` (plain
+/// non-atomic assignment) since the property has not yet been published to
+/// readers.
+#[cfg(feature = "builder")]
+fn init_value_bytes(slot: &mut [AtomicU8; PROP_VALUE_MAX], bytes: &[u8]) {
+    let copy_len = bytes.len().min(PROP_VALUE_MAX - 1);
+    for (i, &b) in bytes[..copy_len].iter().enumerate() {
+        *slot[i].get_mut() = b;
+    }
+    *slot[copy_len].get_mut() = 0;
+}
+
+/// Bounds-checked NUL scan for the long-property variant, returning the raw
+/// bytes (no UTF-8 validation). Callers in the seqlock read loop should
+/// validate the serial first and only then decode.
+///
+/// # Safety
+/// Caller must guarantee that `info + bound_from_info` does not exceed the
+/// mmap allocation containing `info`. This function further reduces the read
+/// span by `offset` so the scan stays within the allocation.
+unsafe fn long_value_bytes(
+    info: &PropertyInfo,
+    offset: usize,
+    bound_from_info: usize,
+) -> Result<Vec<u8>> {
+    let scan_len = bound_from_info.checked_sub(offset).ok_or_else(|| {
+        Error::Encoding(format!(
+            "Long property offset {offset} exceeds mmap bound {bound_from_info}"
+        ))
+    })?;
+    if scan_len == 0 {
+        return Err(Error::Encoding("Long property scan length is zero".into()));
+    }
+    let self_ptr = info as *const _ as *const u8;
+    // SAFETY: `value_ptr` stays within the mmap because `scan_len ==
+    // bound_from_info - offset` and the caller proved `info +
+    // bound_from_info` is in-bounds.
+    let value_ptr = unsafe { self_ptr.add(offset) };
+    // SAFETY: `value_ptr` is in-bounds for `scan_len` bytes by the same
+    // argument. `u8` has no alignment requirement.
+    let bytes = unsafe { std::slice::from_raw_parts(value_ptr, scan_len) };
+    let cstr = CStr::from_bytes_until_nul(bytes).map_err(|e| {
+        Error::Encoding(format!("Long property value missing NUL within bound: {e}"))
+    })?;
+    Ok(cstr.to_bytes().to_vec())
+}
+
 #[inline(always)]
-pub(crate) fn name_from_trailing_data<I: Sized>(
-    thiz: &I,
-    len: Option<usize>,
-) -> crate::errors::Result<&CStr> {
+pub(crate) fn name_from_trailing_data<I: Sized>(thiz: &I, len: Option<usize>) -> Result<&CStr> {
+    // The unbounded variant (`len == None`) is intentionally disallowed: a
+    // missing terminator on a corrupted file would otherwise let the scan
+    // run past the mmap. Callers must supply an upper bound.
+    let len = len.ok_or_else(|| {
+        Error::Encoding("name_from_trailing_data requires a bounded length".into())
+    })?;
     // SAFETY: `thiz` points into a memory-mapped property file laid out as a
-    // header (`I`) immediately followed by `len + 1` bytes of name data when
-    // `len` is `Some`, or a null-terminated C string when `len` is `None`.
-    // - `Some(len)` branch: caller guarantees `len + 1` bytes (including the
-    //   terminator) are mapped after `thiz`. `from_bytes_until_nul` reads at
-    //   most that many bytes and returns `Err` if no null is found.
-    // - `None` branch: caller guarantees the bytes after `thiz` form a
-    //   null-terminated string within the mapping. Without an upper bound,
-    //   a missing terminator would read past the mapping — this is a known
-    //   residual risk that requires propagating the buffer length to fix.
+    // header (`I`) immediately followed by `len + 1` bytes of name data. The
+    // caller (a property area / trie helper) guarantees that the bytes from
+    // `thiz + size_of::<I>()` up to `+ len + 1` are within the mapping.
     unsafe {
         let thiz_ptr = thiz as *const _ as *const u8;
-        let name_ptr = thiz_ptr.add(mem::size_of::<I>()) as _;
-        match len {
-            Some(len) => CStr::from_bytes_until_nul(std::slice::from_raw_parts(name_ptr, len + 1))
-                .map_err(|e| {
-                    crate::errors::Error::new_encoding(format!(
-                        "Failed to convert name to CStr: {e}"
-                    ))
-                }),
-            None => Ok(CStr::from_ptr(name_ptr as *const _)),
-        }
+        let name_ptr = thiz_ptr.add(mem::size_of::<I>());
+        CStr::from_bytes_until_nul(std::slice::from_raw_parts(name_ptr, len + 1))
+            .map_err(|e| Error::Encoding(format!("Failed to convert name to CStr: {e}")))
     }
 }
 
 #[cfg(feature = "builder")]
 #[inline(always)]
 pub(crate) fn init_name_with_trailing_data<I: Sized>(thiz: &mut I, name: &str) {
+    // SAFETY: callers (the property area allocator) reserve
+    // `size_of::<I>() + name.len() + 1` bytes when constructing the trailing-
+    // name layout, so writing `name.len() + 1` bytes after `thiz` is in-bounds.
+    // `&mut thiz` guarantees exclusive access.
     unsafe {
         let thiz_ptr = thiz as *mut _ as *mut u8;
-        let name_ptr = thiz_ptr.add(mem::size_of::<I>()) as _;
+        let name_ptr = thiz_ptr.add(mem::size_of::<I>());
 
         ptr::copy_nonoverlapping(name.as_ptr(), name_ptr, name.len());
         *name_ptr.add(name.len()) = 0; // Add null terminator

--- a/rsproperties/src/property_info.rs
+++ b/rsproperties/src/property_info.rs
@@ -133,8 +133,7 @@ impl PropertyInfo {
     /// reader may observe partially-written multi-byte sequences that
     /// would otherwise spuriously fail `String::from_utf8` and abort the
     /// retry loop. Callers that need a `String` should validate the
-    /// serial first, then call [`Self::value_as_string`] or convert
-    /// directly via `String::from_utf8`.
+    /// serial first, then convert via `String::from_utf8`.
     ///
     /// `long_value_bound` is an upper bound on how far past `self` the
     /// long variant may extend. For the short variant this argument is

--- a/rsproperties/src/property_info.rs
+++ b/rsproperties/src/property_info.rs
@@ -106,6 +106,11 @@ impl PropertyInfo {
     ///
     /// `bound` caps the NUL scan at the remaining mmap extent past `self`,
     /// computed by the enclosing `PropertyAreaMap` via `max_value_bound`.
+    ///
+    /// Gated on `builder` because the only caller is `update`'s `ro.`
+    /// validation, which itself is builder-only. Without the gate this
+    /// would be dead code in default Android builds.
+    #[cfg(feature = "builder")]
     pub(crate) fn name(&self, bound: usize) -> Result<&CStr> {
         let header = mem::size_of::<PropertyInfo>();
         // `name_from_trailing_data` reads `len + 1` bytes; bail out when the
@@ -167,17 +172,6 @@ impl PropertyInfo {
                 Ok(std::borrow::Cow::Borrowed(read_value_atomic(slot, buf)))
             }
         }
-    }
-
-    /// Convenience: reads the value AND validates UTF-8 in one step. Use
-    /// only outside the seqlock read loop — for retry-friendly reads, call
-    /// [`Self::value_bytes`] and validate after the serial re-check.
-    pub(crate) fn value(&self, long_value_bound: usize) -> Result<String> {
-        let mut buf = [0u8; PROP_VALUE_MAX];
-        let bytes = self.value_bytes(long_value_bound, &mut buf)?;
-        std::str::from_utf8(&bytes)
-            .map(str::to_owned)
-            .map_err(|e| Error::Encoding(format!("property value is not valid UTF-8: {e}")))
     }
 
     pub(crate) fn is_long(&self) -> bool {

--- a/rsproperties/src/property_info.rs
+++ b/rsproperties/src/property_info.rs
@@ -134,12 +134,18 @@ impl PropertyInfo {
     /// `long_value_bound` is an upper bound on how far past `self` the
     /// long variant may extend. For the short variant this argument is
     /// ignored.
-    /// Reads short-variant bytes into `buf` (no allocation); returns the
-    /// populated prefix. The long variant still allocates because its data
-    /// lives out-of-line in the mmap and a stack buffer can't bound its
-    /// length statically.
+    /// Reads short-variant bytes into `buf`; returns the populated prefix.
+    /// The long variant borrows bytes directly from the mmap — long
+    /// properties are write-once (`apply_write` rejects LONG entries), so
+    /// the out-of-line bytes are stable for the lifetime of the mapping.
+    ///
+    /// Lifetime invariant: both `self` and `buf` are bound to `'a`, so the
+    /// returned `Cow` is valid for whichever of the two ends first (the
+    /// shorter, in practice usually `buf`'s scope). Tying both to a single
+    /// lifetime is what lets the long path return `Cow::Borrowed` from the
+    /// mmap without leaking past `self`'s borrow.
     pub(crate) fn value_bytes<'a>(
-        &self,
+        &'a self,
         long_value_bound: usize,
         buf: &'a mut [u8; PROP_VALUE_MAX],
     ) -> Result<std::borrow::Cow<'a, [u8]>> {
@@ -152,7 +158,7 @@ impl PropertyInfo {
                 let offset = long_property.offset.load(Ordering::Relaxed) as usize;
                 long_value_bytes(self, offset, long_value_bound)?
             };
-            Ok(std::borrow::Cow::Owned(bytes))
+            Ok(std::borrow::Cow::Borrowed(bytes))
         } else {
             // SAFETY: when the LONG flag is clear the union variant is the
             // byte-wise atomic `value` array of size `PROP_VALUE_MAX`.
@@ -314,8 +320,12 @@ fn init_value_bytes(slot: &mut [AtomicU8; PROP_VALUE_MAX], bytes: &[u8]) {
 }
 
 /// Bounds-checked NUL scan for the long-property variant, returning the raw
-/// bytes (no UTF-8 validation). Callers in the seqlock read loop should
-/// validate the serial first and only then decode.
+/// bytes (no UTF-8 validation) borrowed from the mmap.
+///
+/// Long properties are write-once: `apply_write` rejects entries with the
+/// LONG flag set, so once the entry is initialised the out-of-line bytes
+/// never change. That immutability is what lets the reader borrow the
+/// bytes directly instead of copying them into a `Vec<u8>`.
 ///
 /// # Safety
 /// Caller must guarantee that `info + bound_from_info` does not exceed the
@@ -325,7 +335,7 @@ unsafe fn long_value_bytes(
     info: &PropertyInfo,
     offset: usize,
     bound_from_info: usize,
-) -> Result<Vec<u8>> {
+) -> Result<&[u8]> {
     let scan_len = bound_from_info.checked_sub(offset).ok_or_else(|| {
         Error::Encoding(format!(
             "Long property offset {offset} exceeds mmap bound {bound_from_info}"
@@ -340,12 +350,13 @@ unsafe fn long_value_bytes(
     // bound_from_info` is in-bounds.
     let value_ptr = unsafe { self_ptr.add(offset) };
     // SAFETY: `value_ptr` is in-bounds for `scan_len` bytes by the same
-    // argument. `u8` has no alignment requirement.
+    // argument. `u8` has no alignment requirement. The borrow is tied to
+    // `'a` (the `&'a PropertyInfo`), so it can't outlive the mmap.
     let bytes = unsafe { std::slice::from_raw_parts(value_ptr, scan_len) };
     let cstr = CStr::from_bytes_until_nul(bytes).map_err(|e| {
         Error::Encoding(format!("Long property value missing NUL within bound: {e}"))
     })?;
-    Ok(cstr.to_bytes().to_vec())
+    Ok(cstr.to_bytes())
 }
 
 #[inline(always)]

--- a/rsproperties/src/property_info_parser.rs
+++ b/rsproperties/src/property_info_parser.rs
@@ -10,28 +10,25 @@ use zerocopy_derive::*;
 use crate::errors::*;
 use crate::property_area::MemoryMap;
 
-fn find<F>(array_length: u32, f: F) -> i32
+/// Binary search returning the matching index or `None` for miss. Internal
+/// indexing uses `usize` to avoid `u32 → i32` truncation when
+/// `array_length > i32::MAX`. The callback is `FnMut` so it can record
+/// out-of-band signals (e.g. a corrupted entry) for the caller to inspect.
+fn find<F>(array_length: u32, mut f: F) -> Option<usize>
 where
-    F: Fn(i32) -> Ordering,
+    F: FnMut(usize) -> Ordering,
 {
-    let mut bottom = 0;
-    let mut top = array_length as i32 - 1;
-    while top >= bottom {
-        let search = (top + bottom) / 2;
-
-        match f(search) {
-            Ordering::Equal => {
-                return search;
-            }
-            Ordering::Less => {
-                bottom = search + 1;
-            }
-            Ordering::Greater => {
-                top = search - 1;
-            }
-        };
+    let len = array_length as usize;
+    let (mut lo, mut hi) = (0usize, len);
+    while lo < hi {
+        let mid = lo + (hi - lo) / 2;
+        match f(mid) {
+            Ordering::Equal => return Some(mid),
+            Ordering::Less => lo = mid + 1,
+            Ordering::Greater => hi = mid,
+        }
     }
-    -1
+    None
 }
 
 /// Decodes a trie entry name into a non-empty UTF-8 string.
@@ -152,7 +149,7 @@ impl<'a> TrieNode<'a> {
             .property_info_area
             .u32_slice_from(data.child_nodes as usize);
         let child_node_offset = slice.get(n).ok_or_else(|| {
-            Error::new_file_validation(format!(
+            Error::FileValidation(format!(
                 "Child node index {n} out of bounds: array length {}",
                 slice.len()
             ))
@@ -164,19 +161,38 @@ impl<'a> TrieNode<'a> {
     }
 
     fn find_child_for_string(&'_ self, input: &str) -> Option<TrieNode<'_>> {
-        let node_index = find(self.num_child_nodes(), |i| match self.child_node(i as _) {
+        // On corruption we return `Ordering::Equal`; `find` exits the binary
+        // search immediately so the closure runs at most once after the flag
+        // is set. `corrupted` then disqualifies the index because the
+        // sorted-invariant can no longer be trusted.
+        let mut corrupted = false;
+        let node_index = find(self.num_child_nodes(), |i| match self.child_node(i) {
             Ok(child) => match child.name() {
-                Ok(name) => name.to_str().unwrap_or_default().cmp(input),
-                Err(_) => Ordering::Less,
+                Ok(name) => match name.to_str() {
+                    Ok(s) => s.cmp(input),
+                    Err(e) => {
+                        warn!("child node {i} has non-UTF-8 name: {e}");
+                        corrupted = true;
+                        Ordering::Equal
+                    }
+                },
+                Err(e) => {
+                    warn!("child node {i} name read failed: {e}");
+                    corrupted = true;
+                    Ordering::Equal
+                }
             },
-            Err(_) => Ordering::Less,
+            Err(e) => {
+                warn!("child node {i} read failed: {e}");
+                corrupted = true;
+                Ordering::Equal
+            }
         });
 
-        if node_index < 0 {
-            None
-        } else {
-            self.child_node(node_index as _).ok()
+        if corrupted {
+            return None;
         }
+        node_index.and_then(|i| self.child_node(i).ok())
     }
 
     pub(crate) fn num_prefixes(&self) -> u32 {
@@ -195,7 +211,7 @@ impl<'a> TrieNode<'a> {
             .property_info_area
             .u32_slice_from(data.prefix_entries as usize);
         let offset = *slice.get(n).ok_or_else(|| {
-            Error::new_file_validation(format!(
+            Error::FileValidation(format!(
                 "Prefix index {n} out of bounds: array length {}",
                 slice.len()
             ))
@@ -221,7 +237,7 @@ impl<'a> TrieNode<'a> {
             .property_info_area
             .u32_slice_from(data.exact_match_entries as usize);
         let offset = *slice.get(n).ok_or_else(|| {
-            Error::new_file_validation(format!(
+            Error::FileValidation(format!(
                 "Exact match index {n} out of bounds: array length {}",
                 slice.len()
             ))
@@ -266,10 +282,10 @@ impl<'a> PropertyInfoArea<'a> {
     {
         let size_of = size_of::<T>();
         let end = offset.checked_add(size_of).ok_or_else(|| {
-            Error::new_file_validation(format!("Offset overflow: {offset} + {size_of}"))
+            Error::FileValidation(format!("Offset overflow: {offset} + {size_of}"))
         })?;
         let slice = self.data_base.get(offset..end).ok_or_else(|| {
-            Error::new_file_validation(format!(
+            Error::FileValidation(format!(
                 "Offset out of bounds: {end} > {}",
                 self.data_base.len()
             ))
@@ -277,9 +293,7 @@ impl<'a> PropertyInfoArea<'a> {
         zerocopy::Ref::<&[u8], T>::from_bytes(slice)
             .map(zerocopy::Ref::into_ref)
             .map_err(|e| {
-                Error::new_file_validation(format!(
-                    "Reference creation failed at offset {offset}: {e}"
-                ))
+                Error::FileValidation(format!("Reference creation failed at offset {offset}: {e}"))
             })
     }
 
@@ -349,7 +363,7 @@ impl<'a> PropertyInfoArea<'a> {
         let context_array_offset = self.header().contexts_offset as usize + size_of::<u32>();
         let slice = self.u32_slice_from(context_array_offset);
         let value = slice.get(index).ok_or_else(|| {
-            Error::new_file_validation(format!(
+            Error::FileValidation(format!(
                 "Context index {index} out of bounds: array length {} at offset {context_array_offset}",
                 slice.len()
             ))
@@ -362,7 +376,7 @@ impl<'a> PropertyInfoArea<'a> {
         let type_array_offset = self.header().types_offset as usize + size_of::<u32>();
         let slice = self.u32_slice_from(type_array_offset);
         let value = slice.get(index).ok_or_else(|| {
-            Error::new_file_validation(format!(
+            Error::FileValidation(format!(
                 "Type index {index} out of bounds: array length {} at offset {type_array_offset}",
                 slice.len()
             ))
@@ -488,38 +502,55 @@ impl<'a> PropertyInfoArea<'a> {
         (return_context_index, return_type_index)
     }
 
-    // pub(crate) fn get_property_info(&self, name: &str) -> (Option<&CStr>, Option<&CStr>) {
-    //     let (context_index, type_index) = self.get_property_info_indexes(name);
-    //     let context_cstr = if context_index == !0 {
-    //         None
-    //     } else {
-    //         Some(self.cstr(self.context_offset(context_index as _) as _))
-    //     };
-
-    //     let type_cstr = if type_index == !0 {
-    //         None
-    //     } else {
-    //         Some(self.cstr(self.type_offset(type_index as _) as _))
-    //     };
-    //     (context_cstr, type_cstr)
-    // }
-
     #[cfg(feature = "builder")]
-    pub(crate) fn find_context_index(&self, context: &str) -> i32 {
-        find(self.num_contexts() as _, |i| {
-            match self.context_offset(i as _) {
-                Ok(offset) => self.cstr(offset).to_str().unwrap_or_default().cmp(context),
-                Err(_) => Ordering::Less,
-            }
+    pub(crate) fn find_context_index(&self, context: &str) -> Option<usize> {
+        self.find_string_index(self.num_contexts() as u32, context, "context", |i| {
+            self.context_offset(i)
         })
     }
 
     #[cfg(feature = "builder")]
-    pub(crate) fn find_type_index(&self, rtype: &str) -> i32 {
-        find(self.num_types() as _, |i| match self.type_offset(i as _) {
-            Ok(offset) => self.cstr(offset).to_str().unwrap_or_default().cmp(rtype),
-            Err(_) => Ordering::Less,
+    pub(crate) fn find_type_index(&self, rtype: &str) -> Option<usize> {
+        self.find_string_index(self.num_types() as u32, rtype, "type", |i| {
+            self.type_offset(i)
         })
+    }
+
+    /// Shared binary search for context/type tables. Treats any entry that
+    /// fails to read or is not valid UTF-8 as a corruption signal; once set,
+    /// the search is short-circuited and returns `None` (the table's sorted
+    /// invariant can no longer be trusted).
+    #[cfg(feature = "builder")]
+    fn find_string_index(
+        &self,
+        n: u32,
+        needle: &str,
+        kind: &str,
+        offset_at: impl Fn(usize) -> Result<usize>,
+    ) -> Option<usize> {
+        // Same corruption-handling pattern as `find_child_for_string`: on
+        // failure we return `Equal` (which terminates `find`'s binary
+        // search) and surface the inability-to-trust-sort via `corrupted`.
+        let mut corrupted = false;
+        let idx = find(n, |i| {
+            match offset_at(i).and_then(|off| {
+                self.cstr(off)
+                    .to_str()
+                    .map_err(|e| Error::FileValidation(format!("{kind} entry {i} not UTF-8: {e}")))
+            }) {
+                Ok(s) => s.cmp(needle),
+                Err(e) => {
+                    warn!("{kind} entry {i} read failed: {e}");
+                    corrupted = true;
+                    Ordering::Equal
+                }
+            }
+        });
+        if corrupted {
+            None
+        } else {
+            idx
+        }
     }
 }
 
@@ -560,37 +591,3 @@ impl PropertyInfoAreaFile {
         )
     }
 }
-
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
-
-//     fn test_info_area(info_area: &PropertyInfoArea) {
-//         assert_eq!(info_area.current_version(), 1);
-//         assert_eq!(info_area.minimum_supported_version(), 1);
-
-//         let _num_context_nodes = info_area.num_contexts();
-
-//         let (context_cstr, type_cstr) = info_area.get_property_info("ro.build.version.sdk");
-//         assert_eq!(context_cstr.unwrap().to_str().unwrap(), "u:object_r:build_prop:s0");
-//         assert_eq!(type_cstr.unwrap().to_str().unwrap(), "int");
-//     }
-
-//     #[cfg(target_os = "android")]
-//     #[test]
-//     fn test_property_info_area_file() -> Result<()> {
-//         test_info_area(&PropertyInfoAreaFile::load_default_path()?.property_info_area());
-//         Ok(())
-//     }
-
-//     #[cfg(feature = "builder")]
-//     #[test]
-//     fn test_property_info_area_with_builder() -> Result<()> {
-//         let entries = crate::property_info_serializer::PropertyInfoEntry::parse_from_file(Path::new("tests/android/plat_property_contexts"), false).unwrap();
-//         let data: Vec<u8> = crate::property_info_serializer::build_trie(&entries.0, "u:object_r:build_prop:s0", "string").unwrap();
-
-//         test_info_area(&PropertyInfoArea::new(&data));
-
-//         Ok(())
-//     }
-// }

--- a/rsproperties/src/property_info_serializer.rs
+++ b/rsproperties/src/property_info_serializer.rs
@@ -33,13 +33,7 @@ impl PropertyInfoEntry {
 
         const NO_PARAMETER_TYPES: &[&str] = &["string", "int", "bool", "uint", "double", "size"];
 
-        for no_parameter_type in NO_PARAMETER_TYPES {
-            if type_strings[0] == *no_parameter_type {
-                return true;
-            }
-        }
-
-        false
+        NO_PARAMETER_TYPES.contains(&type_strings[0].as_str())
     }
 
     // Parse a line from the property info file.
@@ -52,20 +46,17 @@ impl PropertyInfoEntry {
     fn parse_from_line(line: &str, require_prefix_or_exact: bool) -> Result<PropertyInfoEntry> {
         let mut tokenizer = line.split_whitespace();
 
-        let property = tokenizer.next().ok_or_else(|| {
-            Error::new_parse(format!("Did not find a property entry in '{line}'"))
-        })?;
+        let property = tokenizer
+            .next()
+            .ok_or_else(|| Error::Parse(format!("Did not find a property entry in '{line}'")))?;
 
         let context = tokenizer
             .next()
-            .ok_or_else(|| Error::new_parse(format!("Did not find a context entry in '{line}'")))?;
+            .ok_or_else(|| Error::Parse(format!("Did not find a context entry in '{line}'")))?;
 
         let match_operation = tokenizer.next();
 
-        let mut type_strings = Vec::new();
-        for type_str in tokenizer {
-            type_strings.push(type_str.to_owned());
-        }
+        let type_strings: Vec<String> = tokenizer.map(str::to_owned).collect();
 
         let mut exact_match = false;
 
@@ -73,14 +64,14 @@ impl PropertyInfoEntry {
             exact_match = true;
         } else if match_operation != Some("prefix") && require_prefix_or_exact {
             error!("Invalid match operation '{match_operation:?}' - must be 'prefix' or 'exact'");
-            return Err(Error::new_parse(format!(
+            return Err(Error::Parse(format!(
                 "Match operation '{match_operation:?}' is not valid. Must be 'prefix' or 'exact'"
             )));
         }
 
         if !type_strings.is_empty() && !Self::is_type_valid(&type_strings) {
             error!("Invalid type specification: '{}'", type_strings.join(" "));
-            return Err(Error::new_parse(format!(
+            return Err(Error::Parse(format!(
                 "Type '{}' is not valid.",
                 type_strings.join(" ")
             )));
@@ -104,7 +95,7 @@ impl PropertyInfoEntry {
             "Parsing property info file: {filename:?} (require_prefix_or_exact={require_prefix_or_exact})"
         );
 
-        let file = File::open(filename).map_err(Error::new_io)?;
+        let file = File::open(filename)?;
         let reader = BufReader::new(file);
 
         let mut errors = Vec::new();
@@ -163,8 +154,8 @@ pub fn build_trie(
         )?;
     }
 
-    let mut serializer = TrieSerializer::new(&trie)?;
-    let data = serializer.take_data();
+    let serializer = TrieSerializer::new(&trie)?;
+    let data = serializer.into_data();
 
     info!(
         "Trie built and serialized successfully: {} bytes",

--- a/rsproperties/src/system_properties.rs
+++ b/rsproperties/src/system_properties.rs
@@ -3,23 +3,20 @@
 
 use std::path::Path;
 use std::sync::atomic::{fence, AtomicU32, Ordering};
+#[cfg(any(target_os = "android", target_os = "linux"))]
+use std::time::{Duration, Instant};
 
+use rustix::fs::Timespec;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 use rustix::thread::futex;
-use rustix::{fs::Timespec, path::Arg};
 
 use crate::errors::*;
 
 use crate::contexts_serialized::ContextsSerialized;
 use crate::property_info::PropertyInfo;
 
-pub(crate) const PROP_VALUE_MAX: usize = 92;
+pub(crate) use crate::wire::PROP_VALUE_MAX;
 pub(crate) const PROP_TREE_FILE: &str = "/dev/__properties__/property_info";
-
-#[inline(always)]
-fn serial_value_len(serial: u32) -> u32 {
-    serial >> 24
-}
 
 #[inline(always)]
 fn serial_dirty(serial: u32) -> bool {
@@ -32,7 +29,6 @@ fn futex_wake(_addr: &AtomicU32) -> Result<usize> {
     {
         futex::wake(_addr, futex::Flags::empty(), i32::MAX as u32)
             .context_with_location("Failed to wake futex")
-        // .map_err(Error::new_errno)
     }
     #[cfg(target_os = "macos")]
     Ok(0)
@@ -40,22 +36,61 @@ fn futex_wake(_addr: &AtomicU32) -> Result<usize> {
 
 fn futex_wait(_serial: &AtomicU32, _value: u32, _timeout: Option<&Timespec>) -> Option<u32> {
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    loop {
-        match futex::wait(_serial, futex::Flags::empty(), _value as _, _timeout) {
-            Ok(_) => {
-                let new_serial = _serial.load(Ordering::Acquire);
-                if _value != new_serial {
-                    return Some(new_serial);
-                }
-            }
-            Err(e) => {
-                log::error!("Failed to wait for property change: {e}");
+    {
+        // Linux futex_wait takes a *relative* timeout. Spurious wakes restart
+        // the syscall, so we track a deadline and shrink the remaining timeout
+        // each iteration to keep the total wait bounded by the caller-supplied
+        // value.
+        //
+        // `Timespec.tv_sec`/`tv_nsec` are signed (i64). Negative values are
+        // not valid timeouts; treat them as immediate timeout to avoid
+        // panicking in `Instant + Duration` from a `usize::MAX`-ish wrap.
+        let deadline = match _timeout {
+            None => None,
+            Some(t) if t.tv_sec < 0 || t.tv_nsec < 0 || t.tv_nsec >= 1_000_000_000 => {
                 return None;
+            }
+            Some(t) => Some(Instant::now() + Duration::new(t.tv_sec as u64, t.tv_nsec as u32)),
+        };
+        loop {
+            let remaining_ts = match deadline {
+                None => None,
+                Some(d) => {
+                    let r = d.saturating_duration_since(Instant::now());
+                    if r.is_zero() {
+                        return None;
+                    }
+                    Some(Timespec {
+                        tv_sec: r.as_secs() as _,
+                        tv_nsec: r.subsec_nanos() as _,
+                    })
+                }
+            };
+            match futex::wait(
+                _serial,
+                futex::Flags::empty(),
+                _value as _,
+                remaining_ts.as_ref(),
+            ) {
+                Ok(_) => {
+                    let new_serial = _serial.load(Ordering::Acquire);
+                    if _value != new_serial {
+                        return Some(new_serial);
+                    }
+                    // Spurious wake — loop with the recomputed remaining timeout.
+                }
+                Err(e) => {
+                    log::error!("Failed to wait for property change: {e}");
+                    return None;
+                }
             }
         }
     }
     #[cfg(target_os = "macos")]
-    None
+    {
+        let _ = (_serial, _value, _timeout);
+        None
+    }
 }
 
 // To avoid lifetime issues, the property index is used to access the property value.
@@ -99,60 +134,74 @@ impl SystemProperties {
         Ok(Self { contexts })
     }
 
-    fn read_mutable_property_value(&self, prop_info: &PropertyInfo) -> Result<(u32, String)> {
+    fn read_mutable_property_value(
+        &self,
+        pa: &crate::property_area::PropertyAreaMap,
+        prop_info: &PropertyInfo,
+    ) -> Result<String> {
+        let bound = pa.max_value_bound(prop_info);
+        // Reused across retries — short-variant reads borrow from this
+        // stack buffer so the seqlock loop allocates nothing.
+        let mut buf = [0u8; PROP_VALUE_MAX];
         loop {
             // Read current serial at the beginning of each iteration
             let serial = prop_info.serial.load(Ordering::Acquire);
-            let _len: u32 = serial_value_len(serial);
 
-            let value = if serial_dirty(serial) {
-                let res = match self
-                    .contexts
-                    .prop_area_for_name(prop_info.name()?.to_str()?)
-                {
-                    Ok(res) => res,
-                    Err(e) => {
-                        log::error!(
-                            "Failed to get property area for name {:?}: {}",
-                            prop_info.name().unwrap_or(c"<unknown>"),
-                            e
-                        );
-                        return Err(e);
-                    }
-                };
-                let pa = res.0.property_area();
-                let value = match pa.dirty_backup_area() {
-                    Ok(value) => value,
-                    Err(e) => {
-                        log::error!("Failed to read dirty backup area: {e}");
-                        return Err(e);
-                    }
-                };
-                value.as_str().map_err(Error::from)?.to_owned()
+            // Read RAW bytes (no UTF-8 validation yet) — byte-wise atomic
+            // reads can surface partially-written multi-byte sequences when
+            // a writer is mid-update. Deferring UTF-8 validation until
+            // *after* the serial re-check lets the retry loop absorb those
+            // spurious decodes instead of bailing on `?`.
+            let bytes: &[u8] = if serial_dirty(serial) {
+                let backup = pa.dirty_backup_area().map_err(|e| {
+                    log::error!("Failed to read dirty backup area: {e}");
+                    e
+                })?;
+                backup.to_bytes()
             } else {
-                let value = prop_info.value()?;
-                value.as_str().map_err(Error::from)?.to_owned()
+                // `value_bytes` returns Cow — short variant borrows `buf`,
+                // long variant materialises a Vec. We bind via match to
+                // keep the borrow alive across the serial re-check.
+                let cow = prop_info.value_bytes(bound, &mut buf)?;
+                // Materialise once-per-iteration into a temporary to feed
+                // the serial-check; on success we'll re-validate UTF-8.
+                let serial_check = {
+                    fence(Ordering::Acquire);
+                    prop_info.serial.load(Ordering::Acquire)
+                };
+                if serial_check == serial {
+                    return std::str::from_utf8(&cow).map(str::to_owned).map_err(|e| {
+                        Error::Encoding(format!("property value is not valid UTF-8: {e}"))
+                    });
+                }
+                continue;
             };
 
-            // Ensure all previous loads are completed before checking serial again
+            // Dirty path: backup is a `&CStr` that doesn't borrow from `buf`,
+            // so the original fence/recheck pattern works as before.
             fence(Ordering::Acquire);
-
-            // Check if serial hasn't changed during our read operation
             let final_serial = prop_info.serial.load(Ordering::Acquire);
             if final_serial == serial {
-                return Ok((serial, value));
+                return std::str::from_utf8(bytes).map(str::to_owned).map_err(|e| {
+                    Error::Encoding(format!("property value is not valid UTF-8: {e}"))
+                });
             }
-
-            // No need for additional fence here as we'll acquire again at loop start
+            // serial changed → retry; spurious UTF-8 from a torn read is
+            // naturally absorbed here.
         }
     }
 
-    fn read(&self, prop_info: &PropertyInfo, is_name: bool) -> Result<(Option<String>, String)> {
-        let (_serial, value) = self.read_mutable_property_value(prop_info)?;
-        let name_cstr = prop_info.name()?;
+    fn read(
+        &self,
+        pa: &crate::property_area::PropertyAreaMap,
+        prop_info: &PropertyInfo,
+        is_name: bool,
+    ) -> Result<(Option<String>, String)> {
+        let value = self.read_mutable_property_value(pa, prop_info)?;
 
         let name = if is_name {
-            Some(name_cstr.to_str()?.to_owned())
+            let bound = pa.max_value_bound(prop_info);
+            Some(prop_info.name(bound)?.to_str()?.to_owned())
         } else {
             None
         };
@@ -173,7 +222,7 @@ impl SystemProperties {
 
         match pa.find(name) {
             Ok(pi) => {
-                let (_name, value) = match self.read(pi.0, false) {
+                let (_name, value) = match self.read(pa, pi.0, false) {
                     Ok(result) => result,
                     Err(e) => {
                         log::error!("Failed to read property {name}: {e}");
@@ -239,10 +288,13 @@ impl SystemProperties {
 
     #[cfg(feature = "builder")]
     pub fn update(&mut self, index: &PropertyIndex, value: &str) -> Result<bool> {
-        if value.len() >= PROP_VALUE_MAX {
-            let error_msg = format!("Value too long: {} (max: {})", value.len(), PROP_VALUE_MAX);
-            log::error!("{error_msg}");
-            return Err(Error::new_file_validation(error_msg));
+        // Pre-flight value-length check — `update` cannot promote to a long
+        // property in-place (`PropertyInfoWriter::apply_write` rejects on
+        // LONG_FLAG). Pass an empty name so the `ro.` exception in
+        // `validate_value_len` doesn't apply here.
+        if let Err(e) = crate::wire::validate_value_len("", value) {
+            log::error!("{e}");
+            return Err(Error::FileValidation(e));
         }
 
         let mut res = match self.contexts.prop_area_mut_with_index(index.context_index) {
@@ -257,76 +309,67 @@ impl SystemProperties {
             }
         };
         let pa = res.property_area_mut();
-        let pi = match pa.property_info(index.property_index) {
-            Ok(pi) => pi,
-            Err(e) => {
+
+        // Inspect through `&pi` first: validate ro., snapshot backup.
+        // `pi` borrow is dropped at the end of this block so we can take
+        // `&mut pa` for `set_dirty_backup_area` immediately after.
+        let backup_value = {
+            let pi = pa.property_info(index.property_index).map_err(|e| {
                 log::error!(
-                    "Failed to get property info for index {}: {}",
-                    index.property_index,
-                    e
+                    "Failed to get property info for index {}: {e}",
+                    index.property_index
                 );
-                return Err(e);
+                e
+            })?;
+            let bound = pa.max_value_bound(pi);
+            let name = pi.name(bound)?.to_bytes();
+            if name.starts_with(b"ro.") {
+                let error_msg = format!("Try to update the read-only property: {name:?}");
+                log::error!("{error_msg}");
+                return Err(Error::PermissionDenied(error_msg));
             }
+            // Pre-flight LONG check: if the entry was created long, we can't
+            // overwrite it in-place. Checking *before* writing the backup
+            // keeps backup_area aligned with the entry it shadows.
+            if pi.is_long() {
+                let error_msg =
+                    format!("in-place update of long property is not supported: {name:?}");
+                log::error!("{error_msg}");
+                return Err(Error::FileValidation(error_msg));
+            }
+            pi.value(bound)?
         };
 
-        let name = pi.name()?.to_bytes();
-        if !name.is_empty() && &name[0..3] == b"ro." {
-            let error_msg = format!("Try to update the read-only property: {name:?}");
-            log::error!("{error_msg}");
-            return Err(Error::new_permission_denied(error_msg));
-        }
+        // Back up the current value so concurrent readers can observe a
+        // consistent snapshot via the dirty bit. No standalone fence needed:
+        // the Release stores inside `apply_write` synchronize this write
+        // with readers.
+        pa.set_dirty_backup_area(&backup_value).map_err(|e| {
+            log::error!("Failed to set backup area: {e}");
+            e
+        })?;
 
-        let mut serial = pi.serial.load(Ordering::Relaxed);
-        let backup_value = pi.value()?.to_owned();
+        // Single-transaction publish: set_dirty → write → publish_serial.
+        // Encapsulated in writer so a half-published state is impossible.
+        let pi = pa.property_info_mut(index.property_index).map_err(|e| {
+            log::error!("Failed to get mutable property info after backup: {e}");
+            e
+        })?;
+        pi.writer().apply_write(value)?;
 
-        // Before updating, the property value must be backed up
-        match pa.set_dirty_backup_area(&backup_value) {
-            Ok(_) => {}
-            Err(e) => {
-                log::error!("Failed to set backup area: {e}");
-                return Err(e);
-            }
-        }
-        fence(Ordering::Release);
-
-        // Set dirty flag
-        serial |= 1;
-        let pi = match pa.property_info(index.property_index) {
-            Ok(pi) => pi,
-            Err(e) => {
-                log::error!("Failed to get property info after backup: {e}");
-                return Err(e);
-            }
-        };
-        pi.serial.store(serial, Ordering::Relaxed);
-
-        // Set the new value
-        pi.set_value(value);
-        fence(Ordering::Release);
-
-        // Set the new serial. It is cleared the dirty flag and set the new length of the value.
-        let new_serial = (value.len() << 24) as u32 | ((serial + 1) & 0xffffff);
-        pi.serial
-            .store(new_serial, std::sync::atomic::Ordering::Relaxed);
-
-        match futex_wake(&pi.serial) {
-            Ok(_) => {}
-            Err(e) => {
-                log::error!("Failed to wake property futex: {e}");
-                return Err(e);
-            }
+        if let Err(e) = futex_wake(&pi.serial) {
+            log::error!("Failed to wake property futex: {e}");
+            return Err(e);
         }
 
         let serial_pa = self.contexts.serial_prop_area();
-        let old_serial = serial_pa.serial().load(Ordering::Relaxed);
-        serial_pa.serial().store(old_serial + 1, Ordering::Release);
+        // Atomic RMW: multiple service writers (or multi-process mmap sharing)
+        // would otherwise lose updates with a load + store pair.
+        serial_pa.serial().fetch_add(1, Ordering::Release);
 
-        match futex_wake(serial_pa.serial()) {
-            Ok(_) => {}
-            Err(e) => {
-                log::error!("Failed to wake global serial futex: {e}");
-                return Err(e);
-            }
+        if let Err(e) = futex_wake(serial_pa.serial()) {
+            log::error!("Failed to wake global serial futex: {e}");
+            return Err(e);
         }
 
         Ok(true)
@@ -334,15 +377,11 @@ impl SystemProperties {
 
     #[cfg(feature = "builder")]
     pub fn add(&mut self, name: &str, value: &str) -> Result<()> {
-        if value.len() >= PROP_VALUE_MAX && !name.starts_with("ro.") {
-            let error_msg = format!(
-                "Value too long: {} (max: {}) for property: {}",
-                value.len(),
-                PROP_VALUE_MAX,
-                name
-            );
-            log::error!("{error_msg}");
-            return Err(Error::new_file_validation(error_msg));
+        // Shared policy across client/server: only `ro.` names may exceed
+        // PROP_VALUE_MAX (stored as long properties).
+        if let Err(e) = crate::wire::validate_value_len(name, value) {
+            log::error!("{e}");
+            return Err(Error::FileValidation(e));
         }
 
         let mut res = match self.contexts.prop_area_mut_for_name(name) {
@@ -363,8 +402,8 @@ impl SystemProperties {
         }
 
         let serial_pa = self.contexts.serial_prop_area();
-        let old_serial = serial_pa.serial().load(Ordering::Relaxed);
-        serial_pa.serial().store(old_serial + 1, Ordering::Release);
+        // Atomic RMW: see note in `update`.
+        serial_pa.serial().fetch_add(1, Ordering::Release);
 
         match futex_wake(serial_pa.serial()) {
             Ok(_) => {}
@@ -382,29 +421,33 @@ impl SystemProperties {
         serial_pa.serial().load(Ordering::Acquire)
     }
 
-    pub fn serial(&self, idx: &PropertyIndex) -> u32 {
-        match self.contexts.prop_area_with_index(idx.context_index).ok() {
-            Some(guard) => {
-                let pa = guard.property_area();
-                match pa.property_info(idx.property_index).ok() {
-                    Some(pi) => pi.serial.load(Ordering::Acquire),
-                    None => {
-                        log::error!(
-                            "Failed to get PropertyInfo for index: {}",
-                            idx.property_index
-                        );
-                        0
-                    }
-                }
-            }
-            None => {
+    /// Reads the per-property serial counter, or `None` if the context/property
+    /// lookup fails. `0` is a valid initial serial, so callers cannot use a
+    /// numeric sentinel — use the `Option` to distinguish absence.
+    pub fn serial(&self, idx: &PropertyIndex) -> Option<u32> {
+        let guard = self
+            .contexts
+            .prop_area_with_index(idx.context_index)
+            .map_err(|e| {
                 log::error!(
-                    "Failed to get PropertyArea for index: {}",
+                    "Failed to get PropertyArea for index {}: {e}",
                     idx.context_index
                 );
-                0
-            }
-        }
+                e
+            })
+            .ok()?;
+        let pa = guard.property_area();
+        let pi = pa
+            .property_info(idx.property_index)
+            .map_err(|e| {
+                log::error!(
+                    "Failed to get PropertyInfo for index {}: {e}",
+                    idx.property_index
+                );
+                e
+            })
+            .ok()?;
+        Some(pi.serial.load(Ordering::Acquire))
     }
 
     pub fn wait_any(&self) -> Option<u32> {

--- a/rsproperties/src/system_properties.rs
+++ b/rsproperties/src/system_properties.rs
@@ -327,10 +327,13 @@ impl SystemProperties {
         };
         let pa = res.property_area_mut();
 
-        // Inspect through `&pi` first: validate ro., snapshot backup.
-        // `pi` borrow is dropped at the end of this block so we can take
-        // `&mut pa` for `set_dirty_backup_area` immediately after.
-        let backup_value = {
+        // Inspect through `&pi` first: validate ro., snapshot backup into a
+        // stack buffer. `pi` borrow is dropped at the end of this block so
+        // we can take `&mut pa` for `set_dirty_backup_area` immediately
+        // after. The buffer outlives the inner borrow scope, so the bytes
+        // it captured remain valid after `pi`/`cow` go out of scope.
+        let mut backup_buf = [0u8; crate::wire::PROP_VALUE_MAX];
+        let backup_len = {
             let pi = pa.property_info(index.property_index).map_err(|e| {
                 log::error!(
                     "Failed to get property info for index {}: {e}",
@@ -354,17 +357,22 @@ impl SystemProperties {
                 log::error!("{error_msg}");
                 return Err(Error::FileValidation(error_msg));
             }
-            pi.value(bound)?
+            // After the LONG check, `value_bytes` is guaranteed to return
+            // the short variant — a `Cow::Borrowed(&backup_buf[..len])`.
+            // Capturing only the length lets us drop the borrow without
+            // losing the bytes that already live in `backup_buf`.
+            pi.value_bytes(bound, &mut backup_buf)?.len()
         };
 
         // Back up the current value so concurrent readers can observe a
         // consistent snapshot via the dirty bit. No standalone fence needed:
         // the Release stores inside `apply_write` synchronize this write
         // with readers.
-        pa.set_dirty_backup_area(&backup_value).map_err(|e| {
-            log::error!("Failed to set backup area: {e}");
-            e
-        })?;
+        pa.set_dirty_backup_area(&backup_buf[..backup_len])
+            .map_err(|e| {
+                log::error!("Failed to set backup area: {e}");
+                e
+            })?;
 
         // Single-transaction publish: set_dirty → write → publish_serial.
         // Encapsulated in writer so a half-published state is impossible.

--- a/rsproperties/src/system_properties.rs
+++ b/rsproperties/src/system_properties.rs
@@ -134,15 +134,32 @@ impl SystemProperties {
         Ok(Self { contexts })
     }
 
-    fn read_mutable_property_value(
+    /// Reads the mutable property value under the seqlock protocol and
+    /// hands the validated `&str` to `f`. The callback is invoked exactly
+    /// once, on the iteration whose pre/post serial reads agree — earlier
+    /// iterations (torn reads, dirty bit set then cleared) are absorbed by
+    /// the retry loop.
+    ///
+    /// Returning a value through `f` instead of allocating a `String` is
+    /// what makes the parse-and-discard hot path (`get<T>`/`get_or<T>`)
+    /// allocation-free for short and long properties alike.
+    fn read_with_callback<R, F>(
         &self,
         pa: &crate::property_area::PropertyAreaMap,
         prop_info: &PropertyInfo,
-    ) -> Result<String> {
+        f: F,
+    ) -> Result<R>
+    where
+        F: FnOnce(&str) -> R,
+    {
         let bound = pa.max_value_bound(prop_info);
         // Reused across retries — short-variant reads borrow from this
         // stack buffer so the seqlock loop allocates nothing.
         let mut buf = [0u8; PROP_VALUE_MAX];
+        // `FnOnce` must be consumed exactly once, but the retry loop may
+        // iterate multiple times. Park it in `Option` so a successful
+        // serial match can `take()` and call it.
+        let mut f = Some(f);
         loop {
             // Read current serial at the beginning of each iteration
             let serial = prop_info.serial.load(Ordering::Acquire);
@@ -159,20 +176,20 @@ impl SystemProperties {
                 })?;
                 backup.to_bytes()
             } else {
-                // `value_bytes` returns Cow — short variant borrows `buf`,
-                // long variant materialises a Vec. We bind via match to
-                // keep the borrow alive across the serial re-check.
+                // `value_bytes` returns Cow — short borrows `buf`, long
+                // borrows directly from the mmap. Either way no heap
+                // allocation. The borrow is alive across the serial
+                // re-check below so we can hand it to `f` on success.
                 let cow = prop_info.value_bytes(bound, &mut buf)?;
-                // Materialise once-per-iteration into a temporary to feed
-                // the serial-check; on success we'll re-validate UTF-8.
                 let serial_check = {
                     fence(Ordering::Acquire);
                     prop_info.serial.load(Ordering::Acquire)
                 };
                 if serial_check == serial {
-                    return std::str::from_utf8(&cow).map(str::to_owned).map_err(|e| {
+                    let s = std::str::from_utf8(&cow).map_err(|e| {
                         Error::Encoding(format!("property value is not valid UTF-8: {e}"))
-                    });
+                    })?;
+                    return Ok(f.take().expect("callback consumed once on success")(s));
                 }
                 continue;
             };
@@ -182,35 +199,29 @@ impl SystemProperties {
             fence(Ordering::Acquire);
             let final_serial = prop_info.serial.load(Ordering::Acquire);
             if final_serial == serial {
-                return std::str::from_utf8(bytes).map(str::to_owned).map_err(|e| {
+                let s = std::str::from_utf8(bytes).map_err(|e| {
                     Error::Encoding(format!("property value is not valid UTF-8: {e}"))
-                });
+                })?;
+                return Ok(f.take().expect("callback consumed once on success")(s));
             }
             // serial changed → retry; spurious UTF-8 from a torn read is
             // naturally absorbed here.
         }
     }
 
-    fn read(
-        &self,
-        pa: &crate::property_area::PropertyAreaMap,
-        prop_info: &PropertyInfo,
-        is_name: bool,
-    ) -> Result<(Option<String>, String)> {
-        let value = self.read_mutable_property_value(pa, prop_info)?;
-
-        let name = if is_name {
-            let bound = pa.max_value_bound(prop_info);
-            Some(prop_info.name(bound)?.to_str()?.to_owned())
-        } else {
-            None
-        };
-
-        Ok((name, value))
-    }
-
-    /// Get property value that returns error for missing properties
-    pub fn get_with_result(&self, name: &str) -> Result<String> {
+    /// Reads `name`'s value and passes it to `f` as `&str` without ever
+    /// materialising an owned `String`. Intended for the parse-and-discard
+    /// hot path (`get<T>`, `get_or<T>`) where the caller does not need
+    /// ownership of the value bytes.
+    ///
+    /// Mirrors bionic's `__system_property_read_callback` pattern. The
+    /// callback runs while the seqlock-validated bytes are still borrowed
+    /// (from `buf` for short properties, from the mmap for long ones), so
+    /// it should be cheap and non-blocking.
+    pub fn read_with<R, F>(&self, name: &str, f: F) -> Result<R>
+    where
+        F: FnOnce(&str) -> R,
+    {
         let res = match self.contexts.prop_area_for_name(name) {
             Ok(res) => res,
             Err(e) => {
@@ -221,18 +232,24 @@ impl SystemProperties {
         let pa = res.0.property_area();
 
         match pa.find(name) {
-            Ok(pi) => {
-                let (_name, value) = match self.read(pa, pi.0, false) {
-                    Ok(result) => result,
-                    Err(e) => {
-                        log::error!("Failed to read property {name}: {e}");
-                        return Err(e);
-                    }
-                };
-                Ok(value)
-            }
+            Ok(pi) => match self.read_with_callback(pa, pi.0, f) {
+                Ok(r) => Ok(r),
+                Err(e) => {
+                    log::error!("Failed to read property {name}: {e}");
+                    Err(e)
+                }
+            },
             Err(e) => Err(e),
         }
+    }
+
+    /// Get property value that returns error for missing properties.
+    ///
+    /// Allocates a `String`; for the parse-and-discard hot path prefer
+    /// [`Self::read_with`], which hands the value as `&str` without
+    /// allocating.
+    pub fn get_with_result(&self, name: &str) -> Result<String> {
+        self.read_with(name, str::to_owned)
     }
 
     /// Get the property index of a system property by name.

--- a/rsproperties/src/system_property_set.rs
+++ b/rsproperties/src/system_property_set.rs
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::io::{prelude::*, IoSlice};
+use std::net::Shutdown;
 use std::os::unix::net::UnixStream;
 use std::sync::OnceLock;
+use std::time::{Duration, Instant};
 use std::{
-    env, fs,
+    env,
     path::{Path, PathBuf},
 };
 
@@ -20,12 +22,9 @@ pub const PROPERTY_SERVICE_FOR_SYSTEM_SOCKET_NAME: &str = "property_service_for_
 const PROP_SERVICE_NAME: &str = "property_service";
 // const PROP_SERVICE_FOR_SYSTEM_NAME: &str = "property_service_for_system";
 
-const PROP_MSG_SETPROP: u32 = 1;
-const PROP_MSG_SETPROP2: u32 = 0x00020001;
-const PROP_SUCCESS: i32 = 0;
-
-const PROP_NAME_MAX: usize = 32;
-const PROP_VALUE_MAX: usize = 92;
+use crate::wire::{
+    PROP_MSG_SETPROP, PROP_MSG_SETPROP2, PROP_NAME_MAX, PROP_SUCCESS, PROP_VALUE_MAX,
+};
 
 /// Global socket directory configuration
 static SOCKET_DIR: OnceLock<PathBuf> = OnceLock::new();
@@ -43,6 +42,13 @@ pub(crate) fn set_socket_dir<P: AsRef<Path>>(dir: P) -> bool {
     let dir_path = dir.as_ref().to_path_buf();
 
     SOCKET_DIR.set(dir_path.clone()).is_ok()
+}
+
+/// `true` once `set_socket_dir` has succeeded (or `socket_dir()` was called
+/// and populated the cell via env/default). Used by `lib::try_init` for
+/// pre-flight checks before committing other globals.
+pub(crate) fn socket_dir_is_set() -> bool {
+    SOCKET_DIR.get().is_some()
 }
 
 /// Get the current socket directory.
@@ -80,29 +86,28 @@ impl ServiceConnection {
     fn new(name: &str) -> Result<Self> {
         let property_service_socket = get_property_service_socket();
 
-        let socket_name = if name == "sys.powerctl" {
+        // Try the system-property socket for `sys.powerctl`, falling back to
+        // the regular service socket if connection fails. Connect itself is
+        // the only authoritative check — `fs::metadata` would race the open.
+        let stream = if name == "sys.powerctl" {
             let system_socket = get_property_service_for_system_socket();
-            if fs::metadata(&system_socket)
-                .map(|metadata| !metadata.permissions().readonly())
-                .is_ok()
-            {
-                system_socket
-            } else {
-                log::warn!("System property service socket is not writable or does not exist, falling back to default: {property_service_socket}");
-                property_service_socket
-            }
+            UnixStream::connect(&system_socket)
+                .or_else(|first_err| {
+                    log::warn!(
+                        "Connect to {system_socket} failed ({first_err}); falling back to {property_service_socket}"
+                    );
+                    UnixStream::connect(&property_service_socket)
+                })?
         } else {
-            property_service_socket
+            UnixStream::connect(&property_service_socket)?
         };
-
-        let stream: UnixStream = UnixStream::connect(&socket_name).map_err(Error::new_io)?;
 
         Ok(Self { stream })
     }
 
     fn recv_i32(&mut self) -> Result<i32> {
         let mut buf = [0u8; 4];
-        self.stream.read_exact(&mut buf).map_err(Error::new_io)?;
+        self.stream.read_exact(&mut buf)?;
         let value = i32::from_ne_bytes(buf);
         Ok(value)
     }
@@ -138,8 +143,8 @@ impl<'a> ServiceWriter<'a> {
     fn send(self, conn: &mut ServiceConnection) -> Result<()> {
         conn.stream
             .write_vectored(&self.buffers)
-            .map_err(Error::new_io)?;
-        conn.stream.flush().map_err(Error::new_io)?;
+            .map_err(Error::Io)?;
+        conn.stream.flush()?;
         Ok(())
     }
 }
@@ -158,38 +163,39 @@ struct PropertyMessage {
 }
 
 impl PropertyMessage {
-    fn new(cmd: u32, name: &str, value: &str) -> Self {
-        let mut name_buf = [0; PROP_NAME_MAX];
-        let mut value_buf = [0; PROP_VALUE_MAX];
-
+    /// Builds a fixed-size wire message. Rejects oversized name/value so the
+    /// SET request cannot silently target a different key than the caller asked
+    /// for. Length checks at the call site are preserved as a defense in depth,
+    /// but this constructor is the type-level enforcement point.
+    fn new(cmd: u32, name: &str, value: &str) -> Result<Self> {
         let name_bytes = name.as_bytes();
         let value_bytes = value.as_bytes();
 
         if name_bytes.len() > PROP_NAME_MAX {
-            log::warn!(
-                "Property name truncated from {} to {} bytes",
+            return Err(Error::FileValidation(format!(
+                "Property name length {} exceeds PROP_NAME_MAX={}",
                 name_bytes.len(),
                 PROP_NAME_MAX
-            );
+            )));
         }
         if value_bytes.len() > PROP_VALUE_MAX {
-            log::warn!(
-                "Property value truncated from {} to {} bytes",
+            return Err(Error::FileValidation(format!(
+                "Property value length {} exceeds PROP_VALUE_MAX={}",
                 value_bytes.len(),
                 PROP_VALUE_MAX
-            );
+            )));
         }
 
-        name_buf[..name_bytes.len().min(PROP_NAME_MAX)]
-            .copy_from_slice(&name_bytes[..name_bytes.len().min(PROP_NAME_MAX)]);
-        value_buf[..value_bytes.len().min(PROP_VALUE_MAX)]
-            .copy_from_slice(&value_bytes[..value_bytes.len().min(PROP_VALUE_MAX)]);
+        let mut name_buf = [0u8; PROP_NAME_MAX];
+        let mut value_buf = [0u8; PROP_VALUE_MAX];
+        name_buf[..name_bytes.len()].copy_from_slice(name_bytes);
+        value_buf[..value_bytes.len()].copy_from_slice(value_bytes);
 
-        Self {
+        Ok(Self {
             cmd,
             name: name_buf,
             value: value_buf,
-        }
+        })
     }
 }
 
@@ -211,15 +217,35 @@ fn protocol_version() -> &'static ProtocolVersion {
     })
 }
 
-use rustix::fd::{AsFd, BorrowedFd};
+/// Wait for the V1 server to close the connection by signalling EOF on read.
+/// The server uses connection close as an implicit ack — block until the peer
+/// shuts down its write side or until `timeout` elapses.
+fn wait_for_socket_close(stream: &mut UnixStream, timeout: Duration) -> Result<()> {
+    // Half-close our write side so the server can finish; then drain.
+    let _ = stream.shutdown(Shutdown::Write);
+    let original_timeout = stream.read_timeout().ok().flatten();
+    let _ = stream.set_read_timeout(Some(timeout));
 
-fn wait_for_socket_close(_socket_fd: BorrowedFd<'_>) -> Result<()> {
-    use std::thread;
-    use std::time::Duration;
-
-    // Simple timeout approach - sleep for 250ms
-    thread::sleep(Duration::from_millis(250));
-
+    let started = Instant::now();
+    let mut buf = [0u8; 64];
+    loop {
+        match stream.read(&mut buf) {
+            Ok(0) => break, // EOF — server closed.
+            Ok(_) => {}     // Discard any trailing bytes.
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                if started.elapsed() >= timeout {
+                    log::warn!("wait_for_socket_close: timed out after {timeout:?}");
+                    break;
+                }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {}
+            Err(e) => {
+                let _ = stream.set_read_timeout(original_timeout);
+                return Err(Error::Io(e));
+            }
+        }
+    }
+    let _ = stream.set_read_timeout(original_timeout);
     Ok(())
 }
 
@@ -233,7 +259,7 @@ pub(crate) fn set(name: &str, value: &str) -> Result<()> {
                     name.len(),
                     PROP_NAME_MAX
                 );
-                return Err(Error::new_file_validation(format!(
+                return Err(Error::FileValidation(format!(
                     "Property name is too long: {}",
                     name.len()
                 )));
@@ -245,35 +271,31 @@ pub(crate) fn set(name: &str, value: &str) -> Result<()> {
                     value.len(),
                     PROP_VALUE_MAX
                 );
-                return Err(Error::new_file_validation(format!(
+                return Err(Error::FileValidation(format!(
                     "Property value is too long: {}",
                     value.len()
                 )));
             }
 
             let mut conn = ServiceConnection::new(PROP_SERVICE_NAME)?;
-            let prop_msg = PropertyMessage::new(PROP_MSG_SETPROP, name, value);
+            let prop_msg = PropertyMessage::new(PROP_MSG_SETPROP, name, value)?;
 
             ServiceWriter::new()
                 .write_bytes(prop_msg.as_bytes())
                 .send(&mut conn)?;
 
-            wait_for_socket_close(conn.stream.as_fd())?;
+            wait_for_socket_close(&mut conn.stream, Duration::from_millis(250))?;
         }
         ProtocolVersion::V2 => {
             let value_len = value.len() as u32;
             let name_len = name.len() as u32;
 
-            if value.len() >= PROP_VALUE_MAX && !name.starts_with("ro.") {
-                log::error!(
-                    "Property value too long for V2 protocol (non-ro property): {} >= {}",
-                    value.len(),
-                    PROP_VALUE_MAX
-                );
-                return Err(Error::new_file_validation(format!(
-                    "Property value is too long: {}",
-                    value.len()
-                )));
+            // Shared client/server policy — pre-change V2 was `>= 92` here
+            // while the server validator used `> 92`. Single function avoids
+            // the drift.
+            if let Err(e) = crate::wire::validate_value_len(name, value) {
+                log::error!("V2 reject: {e}");
+                return Err(Error::FileValidation(e));
             }
 
             let mut conn = ServiceConnection::new(name)?;
@@ -288,7 +310,7 @@ pub(crate) fn set(name: &str, value: &str) -> Result<()> {
 
             if res != PROP_SUCCESS {
                 log::error!("Property service returned error for '{name}' = '{value}': 0x{res:X}");
-                return Err(Error::new_io(std::io::Error::other(format!(
+                return Err(Error::Io(std::io::Error::other(format!(
                     "Unable to set property \"{name}\" to \"{value}\": error code: 0x{res:X}"
                 ))));
             }

--- a/rsproperties/src/trie_builder.rs
+++ b/rsproperties/src/trie_builder.rs
@@ -74,7 +74,7 @@ impl TrieBuilderNode {
             Ok(())
         } else {
             error!("Exact match already exists for '{name}'");
-            Err(Error::new_file_validation(format!(
+            Err(Error::FileValidation(format!(
                 "Exact match already exists for '{name}'"
             )))
         }
@@ -96,7 +96,7 @@ impl TrieBuilderNode {
             Ok(())
         } else {
             error!("Prefix already exists for '{name}'");
-            Err(Error::new_file_validation(format!(
+            Err(Error::FileValidation(format!(
                 "Prefix already exists for '{name}'"
             )))
         }
@@ -164,7 +164,7 @@ impl TrieBuilder {
 
         let last_name: &str = name_parts
             .pop()
-            .ok_or(Error::new_parse(format!("No name parts for '{name}'")))?;
+            .ok_or(Error::Parse(format!("No name parts for '{name}'")))?;
 
         for part in name_parts {
             let part = Rc::new(part.to_owned());
@@ -192,7 +192,7 @@ impl TrieBuilder {
 
             if child.context().is_some() || child.rtype().is_some() {
                 error!("Duplicate prefix match detected for '{name}'");
-                return Err(Error::new_file_validation(format!(
+                return Err(Error::FileValidation(format!(
                     "Duplicate prefix match detected for '{name}'"
                 )));
             }

--- a/rsproperties/src/trie_node_arena.rs
+++ b/rsproperties/src/trie_node_arena.rs
@@ -28,7 +28,7 @@ impl TrieNodeArena {
 
         // Bounds checking - always executed
         if offset.saturating_add(size) > self.data.len() {
-            return Err(Error::new_file_validation(format!(
+            return Err(Error::FileValidation(format!(
                 "Object access out of bounds: offset={}, size={}, data_len={}",
                 offset,
                 size,
@@ -39,7 +39,7 @@ impl TrieNodeArena {
         // Alignment checking - always executed
         let align = mem::align_of::<T>();
         if offset % align != 0 {
-            return Err(Error::new_file_validation(format!(
+            return Err(Error::FileValidation(format!(
                 "Object at offset {} is not properly aligned for type {} (alignment={})",
                 offset,
                 std::any::type_name::<T>(),
@@ -68,36 +68,59 @@ impl TrieNodeArena {
         self.allocate_data(size)
     }
 
-    pub(crate) fn uint32_array(&mut self, offset: usize) -> Result<&mut [u32]> {
-        // Bounds checking - always executed
-        if offset > self.data.len() {
-            return Err(Error::new_file_validation(format!(
-                "Array access out of bounds: offset={}, data_len={}",
-                offset,
+    /// Returns a mutable slice of `len` u32 elements starting at `offset`.
+    ///
+    /// The caller must supply the array length so the returned slice does
+    /// not over-extend into adjacent allocations. The previous form derived
+    /// the length from `data.len() - offset`, which after `allocate_data`'s
+    /// `resize(new_size, 0)` could span far beyond the actual allocation
+    /// and allow an out-of-bounds write to silently corrupt other nodes.
+    pub(crate) fn uint32_array(&mut self, offset: usize, len: usize) -> Result<&mut [u32]> {
+        let byte_len = len
+            .checked_mul(mem::size_of::<u32>())
+            .ok_or_else(|| Error::FileValidation(format!("Array len overflow: {len}")))?;
+        let end = offset.checked_add(byte_len).ok_or_else(|| {
+            Error::FileValidation(format!("Array end overflow: offset={offset}, len={len}"))
+        })?;
+
+        if end > self.data.len() {
+            return Err(Error::FileValidation(format!(
+                "Array access out of bounds: offset={offset}, len={len}, byte_end={end}, data_len={}",
                 self.data.len()
             )));
         }
 
-        // Alignment checking - always executed
         if offset % mem::align_of::<u32>() != 0 {
-            return Err(Error::new_file_validation(format!(
-                "Array at offset {} is not properly aligned for u32 (alignment={})",
-                offset,
+            return Err(Error::FileValidation(format!(
+                "Array at offset {offset} is not properly aligned for u32 (alignment={})",
                 mem::align_of::<u32>()
             )));
         }
 
-        let remaining_bytes = self.data.len() - offset;
-        let array_len = remaining_bytes / mem::size_of::<u32>();
+        // The full alignment requirement for `*mut u32` is
+        // `(base_ptr + offset) % 4 == 0`. Since `offset % 4 == 0` is
+        // checked above, the residual requirement is `base_ptr % 4 == 0`.
+        // `Vec<u8>`'s allocator only guarantees `align_of::<u8>() == 1`,
+        // but every supported global allocator returns ≥ 8-byte alignment.
+        // Mirror the `debug_assert!` from `allocate_and_write_uint32` here
+        // so the invariant is documented and checked uniformly.
+        debug_assert_eq!(
+            (self.data.as_mut_ptr() as usize) % mem::align_of::<u32>(),
+            0,
+            "Vec<u8> base pointer must be u32-aligned"
+        );
 
         // SAFETY:
-        // - Bounds checked: offset <= data.len()
-        // - Alignment checked: offset is aligned to u32
-        // - array_len calculated from remaining bytes
+        // - Bounds: `offset + len * size_of::<u32>() <= data.len()` (checked above).
+        // - Alignment: `offset % 4 == 0` (checked above) AND `base_ptr % 4 == 0`
+        //   (debug-asserted above; guaranteed by the global allocator's ≥ 8
+        //   alignment on every supported platform).
+        // - The caller-supplied `len` matches the allocation size; the slice
+        //   exposes exactly the intended array and nothing more.
         unsafe {
             Ok(std::slice::from_raw_parts_mut(
                 self.data.as_mut_ptr().add(offset) as *mut u32,
-                array_len,
+                len,
             ))
         }
     }
@@ -114,13 +137,35 @@ impl TrieNodeArena {
     pub(crate) fn allocate_and_write_uint32(&mut self, value: u32) {
         let offset = self.allocate_data(mem::size_of::<u32>());
 
-        // SAFETY: We just allocated the space and verified alignment in allocate_data
+        // `allocate_data` keeps `current_data_pointer` aligned to `size_of::<u32>()`
+        // (every allocation is rounded up via `bionic_align(..., 4)` and the
+        // pointer starts at 0), so `offset` is u32-aligned. `Vec<u8>`'s buffer
+        // is allocated by the global allocator, which is ≥ 8-byte aligned on
+        // every supported platform, so the resulting `*mut u32` is aligned.
+        debug_assert_eq!(
+            offset % mem::align_of::<u32>(),
+            0,
+            "allocate_data invariant: current_data_pointer must stay u32-aligned"
+        );
+        debug_assert_eq!(
+            (self.data.as_mut_ptr() as usize) % mem::align_of::<u32>(),
+            0,
+            "Vec<u8> base pointer must be u32-aligned"
+        );
+        // SAFETY: bounds (offset + 4 ≤ data.len()) and alignment are both
+        // ensured by the debug_assert!s above; in release mode the same
+        // invariants hold from `allocate_data` + global allocator alignment.
         unsafe {
             let ptr = self.data.as_mut_ptr().add(offset) as *mut u32;
-            *ptr = value;
+            ptr.write(value);
         }
     }
 
+    /// Reserves `size` bytes, rounded up to a multiple of `size_of::<u32>()`,
+    /// from the arena's growing buffer. Returns the byte offset of the
+    /// allocation, which is guaranteed to be `u32`-aligned (the pointer
+    /// starts at 0 and every allocation is u32-aligned in length, so the
+    /// invariant is preserved across calls).
     fn allocate_data(&mut self, size: usize) -> usize {
         let aligned_size = crate::bionic_align(size, mem::size_of::<u32>());
 
@@ -143,12 +188,9 @@ impl TrieNodeArena {
         PropertyInfoArea::new(&self.data)
     }
 
-    pub(crate) fn take_data(&mut self) -> Vec<u8> {
-        let mut data = std::mem::take(&mut self.data);
-        data.truncate(self.current_data_pointer);
-
-        self.current_data_pointer = 0;
-        data
+    pub(crate) fn into_data(mut self) -> Vec<u8> {
+        self.data.truncate(self.current_data_pointer);
+        self.data
     }
 }
 
@@ -205,12 +247,15 @@ mod arena_tests {
         let mut arena = TrieNodeArena::new();
         arena.data = vec![0u8; 100];
 
-        let result = arena.uint32_array(101);
+        // offset alone past end
+        let result = arena.uint32_array(104, 1);
         assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("out of bounds"));
 
-        if let Err(e) = result {
-            assert!(e.to_string().contains("out of bounds"));
-        }
+        // offset + len * 4 past end
+        let result = arena.uint32_array(96, 2);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("out of bounds"));
     }
 
     #[test]
@@ -218,12 +263,12 @@ mod arena_tests {
         let mut arena = TrieNodeArena::new();
         arena.data = vec![0u8; 100];
 
-        let result = arena.uint32_array(3);
+        let result = arena.uint32_array(3, 1);
         assert!(result.is_err());
-
-        if let Err(e) = result {
-            assert!(e.to_string().contains("not properly aligned"));
-        }
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("not properly aligned"));
     }
 
     #[test]
@@ -231,11 +276,8 @@ mod arena_tests {
         let mut arena = TrieNodeArena::new();
         arena.data = vec![0u8; 100];
 
-        let result = arena.uint32_array(0);
-        assert!(result.is_ok());
-
-        let array = result.unwrap();
-        assert_eq!(array.len(), 25); // 100 bytes / 4 bytes per u32
+        let array = arena.uint32_array(0, 25).unwrap();
+        assert_eq!(array.len(), 25);
     }
 
     #[test]
@@ -243,11 +285,16 @@ mod arena_tests {
         let mut arena = TrieNodeArena::new();
         arena.data = vec![0u8; 100];
 
-        // Test with offset
-        let result = arena.uint32_array(20);
-        assert!(result.is_ok());
-
-        let array = result.unwrap();
+        let array = arena.uint32_array(20, 20).unwrap();
         assert_eq!(array.len(), 20); // (100 - 20) / 4 = 20
+    }
+
+    #[test]
+    fn test_uint32_array_len_zero() {
+        let mut arena = TrieNodeArena::new();
+        arena.data = vec![0u8; 100];
+
+        let array = arena.uint32_array(0, 0).unwrap();
+        assert_eq!(array.len(), 0);
     }
 }

--- a/rsproperties/src/trie_serializer.rs
+++ b/rsproperties/src/trie_serializer.rs
@@ -4,13 +4,27 @@
 use std::collections::BTreeSet;
 use std::rc::Rc;
 
-use crate::errors::Result;
+use crate::errors::{Error, Result};
 use crate::property_info_parser::*;
 use crate::trie_builder::*;
 use crate::trie_node_arena::TrieNodeArena;
 
 pub(crate) struct TrieSerializer {
     arena: TrieNodeArena,
+}
+
+/// Resolves an optional context/type name to a u32 index, returning the
+/// `u32::MAX` sentinel for absent or empty values, or when the lookup misses.
+fn resolve_index<F>(name: Option<&str>, mut lookup: F) -> u32
+where
+    F: FnMut(&str) -> Option<usize>,
+{
+    match name {
+        Some(s) if !s.is_empty() => lookup(s)
+            .and_then(|i| u32::try_from(i).ok())
+            .unwrap_or(u32::MAX),
+        _ => u32::MAX,
+    }
 }
 
 impl TrieSerializer {
@@ -28,68 +42,65 @@ impl TrieSerializer {
             header.minimum_supported_version = 1;
         }
 
+        // `arena.size()` is the running write position of the in-memory
+        // `Vec<u8>` arena. The on-disk format stores offsets as `u32`, so
+        // an input that needed > 4 GiB of serialised data couldn't be
+        // expressed regardless — the silent `as u32` truncation here is
+        // bounded by the same format constraint. User-input lengths
+        // (e.g. `property_entry.name.len()` in `write_property_entry`)
+        // use `u32::try_from` so they fail loudly instead.
         this.arena
             .get_object::<PropertyInfoAreaHeader>(header_offset)?
-            .contexts_offset = this.arena.size() as _;
+            .contexts_offset = this.arena.size() as u32;
         this.serialize_strings(&trie_builder.contexts)?;
 
         this.arena
             .get_object::<PropertyInfoAreaHeader>(header_offset)?
-            .types_offset = this.arena.size() as _;
+            .types_offset = this.arena.size() as u32;
         this.serialize_strings(&trie_builder.types)?;
 
         this.arena
             .get_object::<PropertyInfoAreaHeader>(header_offset)?
-            .size = this.arena.size() as _;
+            .size = this.arena.size() as u32;
 
         let root_trie_offset = this.write_trie_node(&trie_builder.root)?;
         this.arena
             .get_object::<PropertyInfoAreaHeader>(header_offset)?
-            .root_offset = root_trie_offset as _;
+            .root_offset = root_trie_offset;
 
         let final_size = this.arena.size();
         this.arena
             .get_object::<PropertyInfoAreaHeader>(header_offset)?
-            .size = final_size as _;
+            .size = final_size as u32;
 
         Ok(this)
     }
 
     fn write_property_entry(&mut self, property_entry: &PropertyEntryBuilder) -> Result<u32> {
-        let context_index = match property_entry.context {
-            Some(ref context) => {
-                if context.is_empty() {
-                    !0
-                } else {
-                    let index = self.arena.info().find_context_index(context);
-                    index
-                }
-            }
-            None => !0,
-        };
-
-        let type_index = match property_entry.rtype {
-            Some(ref rtype) => {
-                if rtype.is_empty() {
-                    !0
-                } else {
-                    let index = self.arena.info().find_type_index(rtype);
-                    index
-                }
-            }
-            None => !0,
-        };
+        let context_index =
+            resolve_index(property_entry.context.as_ref().map(|s| s.as_str()), |s| {
+                self.arena.info().find_context_index(s)
+            });
+        let type_index = resolve_index(property_entry.rtype.as_ref().map(|s| s.as_str()), |s| {
+            self.arena.info().find_type_index(s)
+        });
 
         let entry_offset = self.arena.allocate_object::<PropertyEntry>();
-        let name_offset = self.arena.allocate_and_write_string(&property_entry.name) as _;
+        let name_offset = self.arena.allocate_and_write_string(&property_entry.name) as u32;
+        let namelen = u32::try_from(property_entry.name.len()).map_err(|_| {
+            Error::FileValidation(format!(
+                "Property name too long: {} bytes",
+                property_entry.name.len()
+            ))
+        })?;
 
         let entry = self.arena.get_object::<PropertyEntry>(entry_offset)?;
         entry.name_offset = name_offset;
-        entry.namelen = property_entry.name.len() as _;
-        entry.context_index = context_index as _;
-        entry.type_index = type_index as _;
+        entry.namelen = namelen;
+        entry.context_index = context_index;
+        entry.type_index = type_index;
 
-        Ok(entry_offset as _)
+        Ok(entry_offset as u32)
     }
 
     fn write_trie_node(&mut self, builder_node: &TrieBuilderNode) -> Result<u32> {
@@ -98,26 +109,30 @@ impl TrieSerializer {
         let property_entry = self.write_property_entry(&builder_node.property_entry)?;
         self.arena
             .get_object::<TrieNodeData>(trie_offset)?
-            .property_entry = property_entry as _;
+            .property_entry = property_entry;
 
         // Sort prefixes by length (longest first)
         let mut sorted_prefix_matches: Vec<_> = builder_node.prefixes.iter().collect();
         sorted_prefix_matches.sort_by_key(|b| std::cmp::Reverse(b.name.len()));
 
+        // Counts are bounded by trie input size (≤ a few thousand entries per
+        // pixel build), well below u32::MAX.
         self.arena
             .get_object::<TrieNodeData>(trie_offset)?
-            .num_prefixes = sorted_prefix_matches.len() as _;
+            .num_prefixes = sorted_prefix_matches.len() as u32;
 
         let prefix_entries_array_offset = self
             .arena
             .allocate_uint32_array(sorted_prefix_matches.len());
         self.arena
             .get_object::<TrieNodeData>(trie_offset)?
-            .prefix_entries = prefix_entries_array_offset as _;
+            .prefix_entries = prefix_entries_array_offset as u32;
 
+        let prefix_count = sorted_prefix_matches.len();
         for (i, prefix_entry) in sorted_prefix_matches.iter().enumerate() {
             let offset = self.write_property_entry(prefix_entry)?;
-            self.arena.uint32_array(prefix_entries_array_offset)?[i] = offset;
+            self.arena
+                .uint32_array(prefix_entries_array_offset, prefix_count)?[i] = offset;
         }
 
         // Sort exact matches alphabetically
@@ -126,16 +141,18 @@ impl TrieSerializer {
 
         self.arena
             .get_object::<TrieNodeData>(trie_offset)?
-            .num_exact_matches = sorted_exact_matches.len() as _;
+            .num_exact_matches = sorted_exact_matches.len() as u32;
         let exact_match_entries_array_offset =
             self.arena.allocate_uint32_array(sorted_exact_matches.len());
         self.arena
             .get_object::<TrieNodeData>(trie_offset)?
-            .exact_match_entries = exact_match_entries_array_offset as _;
+            .exact_match_entries = exact_match_entries_array_offset as u32;
 
+        let exact_count = sorted_exact_matches.len();
         for (i, exact_entry) in sorted_exact_matches.iter().enumerate() {
             let offset = self.write_property_entry(exact_entry)?;
-            self.arena.uint32_array(exact_match_entries_array_offset)?[i] = offset;
+            self.arena
+                .uint32_array(exact_match_entries_array_offset, exact_count)?[i] = offset;
         }
 
         // Sort children alphabetically
@@ -144,33 +161,36 @@ impl TrieSerializer {
 
         self.arena
             .get_object::<TrieNodeData>(trie_offset)?
-            .num_child_nodes = sorted_children.len() as _;
+            .num_child_nodes = sorted_children.len() as u32;
         let children_offset_array_offset = self.arena.allocate_uint32_array(sorted_children.len());
         self.arena
             .get_object::<TrieNodeData>(trie_offset)?
-            .child_nodes = children_offset_array_offset as _;
+            .child_nodes = children_offset_array_offset as u32;
 
+        let children_count = sorted_children.len();
         for (i, child_node) in sorted_children.iter().enumerate() {
             let child_offset = self.write_trie_node(child_node)?;
-            self.arena.uint32_array(children_offset_array_offset)?[i] = child_offset;
+            self.arena
+                .uint32_array(children_offset_array_offset, children_count)?[i] = child_offset;
         }
 
-        Ok(trie_offset as _)
+        Ok(trie_offset as u32)
     }
 
     fn serialize_strings(&mut self, strings: &BTreeSet<Rc<String>>) -> Result<()> {
-        self.arena.allocate_and_write_uint32(strings.len() as _);
-        let offset_array_offset = self.arena.allocate_uint32_array(strings.len());
+        self.arena.allocate_and_write_uint32(strings.len() as u32);
+        let n = strings.len();
+        let offset_array_offset = self.arena.allocate_uint32_array(n);
 
         for (i, string) in strings.iter().enumerate() {
             let offset = self.arena.allocate_and_write_string(string);
-            self.arena.uint32_array(offset_array_offset)?[i] = offset as _;
+            self.arena.uint32_array(offset_array_offset, n)?[i] = offset as u32;
         }
 
         Ok(())
     }
 
-    pub(crate) fn take_data(&mut self) -> Vec<u8> {
-        self.arena.take_data()
+    pub(crate) fn into_data(self) -> Vec<u8> {
+        self.arena.into_data()
     }
 }

--- a/rsproperties/src/wire.rs
+++ b/rsproperties/src/wire.rs
@@ -1,0 +1,143 @@
+// Copyright 2024 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+//! Wire-protocol constants and shared validators.
+//!
+//! This module is the single source-of-truth for values that cross the
+//! property-service Unix-socket boundary. Both the client (`system_property_set`)
+//! and the server (`rsproperties-service`) must agree on these — duplicating
+//! them in each crate would let "client rejects, server accepts" drift sneak in.
+
+/// Hard cap on property-value byte length (NUL **not** included). Matches the
+/// historical bionic `PROP_VALUE_MAX = 92` constant. Long `ro.` properties
+/// bypass this via the long-property path in [`crate::property_info`].
+pub const PROP_VALUE_MAX: usize = 92;
+
+/// Hard cap on property-name byte length in the **V1 wire protocol** only
+/// (V1's message buffer is a fixed `[u8; PROP_NAME_MAX]`). The V2 protocol
+/// is length-prefixed and does not impose this limit at the wire layer —
+/// AOSP `init/property_service.cpp::IsLegalPropertyName` likewise doesn't
+/// enforce a length on V2.
+pub const PROP_NAME_MAX: usize = 32;
+
+/// V1 SETPROP wire command id.
+pub const PROP_MSG_SETPROP: u32 = 1;
+/// V2 SETPROP wire command id (length-prefixed name/value).
+pub const PROP_MSG_SETPROP2: u32 = 0x00020001;
+
+/// V2 success response code.
+pub const PROP_SUCCESS: i32 = 0;
+/// V2 generic error response code.
+pub const PROP_ERROR: i32 = -1;
+
+/// Decides whether a property value's byte length is acceptable.
+///
+/// Single policy used by both `system_property_set` (client) and the
+/// service handler. Pre-change those two sites disagreed on whether the
+/// comparison was `>` or `>=` — a value of exactly [`PROP_VALUE_MAX`]
+/// bytes could be sent by the client and then rejected by the server (or
+/// vice versa).
+///
+/// Names starting with `ro.` are allowed to exceed the limit (the server
+/// stores them as long properties).
+pub fn validate_value_len(name: &str, value: &str) -> Result<(), String> {
+    if value.len() >= PROP_VALUE_MAX && !name.starts_with("ro.") {
+        return Err(format!(
+            "value too long: {} bytes (max {} for non-'ro.' properties)",
+            value.len(),
+            PROP_VALUE_MAX
+        ));
+    }
+    Ok(())
+}
+
+/// AOSP `init/property_service.cpp::IsLegalPropertyName` parity (V2 path).
+///
+/// - non-empty
+/// - first char is `_` or ASCII alphanumeric (rejects `-foo`, `@foo`, `:foo`)
+/// - cannot end with `.`
+/// - no consecutive `.`
+/// - allowed chars: ASCII alphanumeric, `_`, `.`, `-`, `@`, `:`
+///
+/// The V1 wire protocol additionally enforces `name.len() <= PROP_NAME_MAX`
+/// at the message-encoding layer; V2 has no length cap here.
+pub fn validate_property_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("name is empty".into());
+    }
+    let first = name.chars().next().expect("non-empty");
+    if !(first.is_ascii_alphanumeric() || first == '_') {
+        return Err(format!("name must start with alphanumeric or '_': {name}"));
+    }
+    if name.ends_with('.') {
+        return Err(format!("name cannot end with '.': {name}"));
+    }
+    let mut prev_dot = false;
+    for c in name.chars() {
+        let ok = c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '-' | '@' | ':');
+        if !ok {
+            return Err(format!("invalid char {c:?} in name: {name}"));
+        }
+        if c == '.' && prev_dot {
+            return Err(format!("consecutive '.' in name: {name}"));
+        }
+        prev_dot = c == '.';
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn value_len_short_ok() {
+        assert!(validate_value_len("foo", "x".repeat(PROP_VALUE_MAX - 1).as_str()).is_ok());
+    }
+
+    #[test]
+    fn value_len_at_cap_rejected_for_non_ro() {
+        assert!(validate_value_len("foo", "x".repeat(PROP_VALUE_MAX).as_str()).is_err());
+    }
+
+    #[test]
+    fn value_len_at_cap_ok_for_ro() {
+        assert!(validate_value_len("ro.foo", "x".repeat(PROP_VALUE_MAX * 10).as_str()).is_ok());
+    }
+
+    #[test]
+    fn name_basic_ok() {
+        assert!(validate_property_name("ro.build.version.sdk").is_ok());
+        assert!(validate_property_name("_internal.flag").is_ok());
+        assert!(validate_property_name("a").is_ok());
+    }
+
+    #[test]
+    fn name_rejects_empty() {
+        assert!(validate_property_name("").is_err());
+    }
+
+    #[test]
+    fn name_rejects_leading_non_alnum() {
+        assert!(validate_property_name(".leading.dot").is_err());
+        assert!(validate_property_name("-leading.dash").is_err());
+        assert!(validate_property_name("@leading.at").is_err());
+        assert!(validate_property_name(":leading.colon").is_err());
+    }
+
+    #[test]
+    fn name_rejects_trailing_dot() {
+        assert!(validate_property_name("trailing.dot.").is_err());
+    }
+
+    #[test]
+    fn name_rejects_consecutive_dots() {
+        assert!(validate_property_name("double..dot").is_err());
+    }
+
+    #[test]
+    fn name_rejects_invalid_chars() {
+        assert!(validate_property_name("has space").is_err());
+        assert!(validate_property_name("has/slash").is_err());
+    }
+}

--- a/rsproperties/src/wire.rs
+++ b/rsproperties/src/wire.rs
@@ -10,7 +10,7 @@
 
 /// Hard cap on property-value byte length (NUL **not** included). Matches the
 /// historical bionic `PROP_VALUE_MAX = 92` constant. Long `ro.` properties
-/// bypass this via the long-property path in [`crate::property_info`].
+/// bypass this via the long-property path in `property_info`.
 pub const PROP_VALUE_MAX: usize = 92;
 
 /// Hard cap on property-name byte length in the **V1 wire protocol** only


### PR DESCRIPTION
## Summary

Two themes, four commits.

**Zero-copy on the read hot path** ([ba686d9](https://github.com/hiking90/rsproperties/commit/ba686d9), [f0a6288](https://github.com/hiking90/rsproperties/commit/f0a6288))
- `long_value_bytes` borrows the long-property bytes directly from the mmap (was a `Vec<u8>` copy). Long entries are write-once, so the borrow is stable for the lifetime of the mapping.
- New `SystemProperties::read_with(name, FnOnce(&str) -> R)`, mirroring bionic's `__system_property_read_callback`. The seqlock-validated `&str` is handed to the caller without ever materialising an owned `String`.
- `get<T>` / `get_or<T>` route through `read_with` so the parse-and-discard hot path allocates nothing. `get_with_result` stays as a thin String wrapper for back-compat.
- `update`'s backup snapshot streams the current short-variant value straight from the byte-atomic mmap slot into a stack buffer (via `value_bytes`) and hands the buffer slice to `set_dirty_backup_area`, which now takes `&[u8]`. Eliminates one heap allocation per update — hot during build.prop load.
- Dead-code removals: `PropertyInfo::value()` convenience wrapper. Builder-only gating on `PropertyInfo::name()`.

**`rsproperties-service` hardening** ([5b57195](https://github.com/hiking90/rsproperties/commit/5b57195), [0651753](https://github.com/hiking90/rsproperties/commit/0651753))
- Correctness/panic-safety pass on the earlier commit (lock poisoning, unwrap removal, etc.).
- `rsproperties::try_init` propagation so misconfigured paths surface at startup instead of binding to a previous instance's directories.
- `PropertiesService::on_start` blocking I/O moved into `spawn_blocking` so the tokio worker can drive `SocketService` during init.
- Build.prop entries are loaded into a `HashMap` (the existing parser API) then re-collected into a `BTreeMap` before the apply loop — apply order is now deterministic across runs, no longer following HashMap's randomised hash seed.
- Bound Unix sockets get an explicit `chmod 0o660`, removing the umask dependency.
- Connection-limit permit is acquired **before** `accept()`. When 64 handlers are in-flight, the accept loop parks and new `connect()` attempts queue in the kernel listen backlog instead of being accepted-then-stalled.
- `accept()` errors back off 100ms so EMFILE/ENFILE conditions don't saturate the log.
- Wire-length sanity bounds named (`MAX_WIRE_NAME_LEN`, `MAX_WIRE_VALUE_LEN`).
- `PropertyMessage` gets a manual `Debug` impl that prints `value` as `<N bytes>`. Server logs replaced value content with length too — names are public on the wire, values may not be.

## Test plan

- [x] macOS (`--all-features`): build, clippy (no warnings), full workspace test suite
- [x] archlinux 7.0.3 / rustc 1.95 (`--all-features`): build, clippy, full workspace test suite
- [x] Android emulator arm64-v8a (default features, no builder) on emulator-5554 + emulator-5556: cross-build via cargo-ndk, `getprop`/`setprop` smoke, integration tests across 8 binaries — 59 tests passing on each emulator