### PR TITLE
refactor: drop redundant clones on init and trie-walk paths

### DIFF
--- a/rsproperties/src/lib.rs
+++ b/rsproperties/src/lib.rs
@@ -246,10 +246,10 @@ pub fn try_init(config: PropertyConfig) -> Result<()> {
         ));
     }
 
-    SYSTEM_PROPERTIES_DIR.set(props_dir.clone()).map_err(|_| {
+    log::info!("Setting system properties directory to: {props_dir:?}");
+    SYSTEM_PROPERTIES_DIR.set(props_dir).map_err(|_| {
         Error::FileValidation("System properties directory already initialized".into())
     })?;
-    log::info!("Successfully set system properties directory to: {props_dir:?}");
 
     if let Some(socket_dir) = config.socket_dir {
         if !system_property_set::set_socket_dir(&socket_dir) {

--- a/rsproperties/src/property_info_parser.rs
+++ b/rsproperties/src/property_info_parser.rs
@@ -94,7 +94,7 @@ pub struct TrieNode<'a> {
 impl<'a> TrieNode<'a> {
     fn new(property_info_area: &'a PropertyInfoArea, trie_node_offset: usize) -> Self {
         Self {
-            property_info_area: property_info_area.clone(),
+            property_info_area: *property_info_area,
             trie_node_offset,
         }
     }
@@ -246,7 +246,7 @@ impl<'a> TrieNode<'a> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct PropertyInfoArea<'a> {
     data_base: &'a [u8],
 }
@@ -254,11 +254,6 @@ pub struct PropertyInfoArea<'a> {
 impl<'a> PropertyInfoArea<'a> {
     pub(crate) fn new(data_base: &'a [u8]) -> Self {
         Self { data_base }
-    }
-
-    // To resolve lifetime issues, we need to clone the TrieNode.
-    fn clone_trie_node(&'_ self, trie_node: &TrieNode) -> TrieNode<'_> {
-        TrieNode::new(self, trie_node.trie_node_offset)
     }
 
     pub(crate) fn cstr(&self, offset: usize) -> &CStr {
@@ -447,7 +442,7 @@ impl<'a> PropertyInfoArea<'a> {
                     match trie_node.find_child_for_string(segment) {
                         Some(node) => {
                             remaining_name = &remaining_name[index + 1..];
-                            trie_node = self.clone_trie_node(&node);
+                            trie_node = TrieNode::new(self, node.trie_node_offset);
                         }
                         None => {
                             break;

--- a/rsproperties/src/system_property_set.rs
+++ b/rsproperties/src/system_property_set.rs
@@ -41,7 +41,7 @@ static SOCKET_DIR: OnceLock<PathBuf> = OnceLock::new();
 pub(crate) fn set_socket_dir<P: AsRef<Path>>(dir: P) -> bool {
     let dir_path = dir.as_ref().to_path_buf();
 
-    SOCKET_DIR.set(dir_path.clone()).is_ok()
+    SOCKET_DIR.set(dir_path).is_ok()
 }
 
 /// `true` once `set_socket_dir` has succeeded (or `socket_dir()` was called


### PR DESCRIPTION
## Summary
- Audited every `.clone()` site in `rsproperties` / `rsproperties-service` (tests/examples excluded) and removed the three that were genuinely redundant.
- `Arc`/`Rc`/`ActorRef` clones are kept — they back required multi-owner semantics (`acquire_owned`, `tokio::spawn`'s `'static` capture, BTreeSet + node co-ownership).

## Changes
- `set_socket_dir` ([rsproperties/src/system_property_set.rs](rsproperties/src/system_property_set.rs)): self-clone of a locally-owned `PathBuf` removed; the value now moves straight into `SOCKET_DIR.set(...)`.
- `try_init` ([rsproperties/src/lib.rs](rsproperties/src/lib.rs)): log moved before `SYSTEM_PROPERTIES_DIR.set(...)` and reworded to "Setting ... to", so the owned `PathBuf` can move into the cell instead of being cloned for a post-set log.
- `PropertyInfoArea` ([rsproperties/src/property_info_parser.rs](rsproperties/src/property_info_parser.rs)): now `#[derive(Debug, Clone, Copy)]`. The struct is a single `&[u8]` view; deriving `Copy` removes the noisy `.clone()` in `TrieNode::new` and lets us delete the `clone_trie_node` lifetime-rebinding helper, which collapses to a single `TrieNode::new(self, node.trie_node_offset)` at its only call site.

Net diff: `3 files changed, 6 insertions(+), 11 deletions(-)`.

## Test plan
- [x] `cargo check --all-features --workspace`
- [x] `cargo clippy --all-features --workspace --no-deps` (no new warnings)
- [x] `cargo test --all-features --workspace --lib` (28 library tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)