### PR TITLE
ci(android): bump emulator memory to fix API 34 OOM

### DIFF
--- a/.github/workflows/android-test.yml
+++ b/.github/workflows/android-test.yml
@@ -127,7 +127,7 @@ jobs:
         $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/avdmanager list avd
         if [ -f "$HOME/.android/avd/test-api${{ matrix.api-level }}.avd/config.ini" ]; then
           echo "AVD config found, starting emulator..."
-          nohup $ANDROID_SDK_ROOT/emulator/emulator -avd test-api${{ matrix.api-level }} -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-snapshot -wipe-data > emulator.log 2>&1 &
+          nohup $ANDROID_SDK_ROOT/emulator/emulator -avd test-api${{ matrix.api-level }} -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-snapshot -wipe-data -memory 4096 -partition-size 2048 > emulator.log 2>&1 &
           echo "Emulator started in background"
           sleep 10
           echo "Checking emulator log..."


### PR DESCRIPTION
## Summary
- API 34 x86_64 emulator job was failing in `ndk_prepare` with `fork failed: Out of memory` (exit 126) on a plain `adb shell mkdir -p` — see run [26511693931](https://github.com/hiking90/rsproperties/actions/runs/26511693931/job/78077696450).
- Root cause: emulator was launched with the default ~1.5 GB RAM, which leaves no fork headroom on API 34 once system_server, Zygote, and SwiftShader GPU emulation are up. API 28/30/36 happened to fit; 34 didn't.
- Fix: pass `-memory 4096 -partition-size 2048` to the emulator on startup. `ubuntu-latest` runners have 16 GB so this is well within budget.

## Test plan
- [ ] Re-run the `Android Test (Multiple API Levels)` workflow on this branch via `workflow_dispatch` and confirm all four API levels (28, 30, 34, 36) reach `Run tests on Android device` and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)