### PR TITLE
deps: bump rsactor to 0.16 and migrate SocketService to on_idle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,9 +485,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rsactor"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1203dcdc2982b5ebea387de942a4905838975b40954bf69336c04f99ab7f436"
+checksum = "3a8fe40ccb56316045667a08fa7fb562e4b5601fb332613dcf370cd6c40487f8"
 dependencies = [
  "futures",
  "rsactor-derive",
@@ -497,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "rsactor-derive"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a36233d402aa75c2b7a3d379c961a950f54a5eff6daa0c6d656f427400dbb5f8"
+checksum = "a97e063567221ff983eb14a55b214bc33976ca8148a4d3017186d54426bf25e6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -535,6 +535,7 @@ dependencies = [
  "rsproperties",
  "thiserror",
  "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -658,6 +659,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,8 @@ thiserror = "2.0"
 anyhow = "1.0"
 pretty-hex = "0.4"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time", "net", "io-util", "signal", "fs"] }
-rsactor = "0.15"
+tokio-stream = { version = "0.1", features = ["net"] }
+rsactor = "0.16"
 
 # Dev dependencies
 android_system_properties = "0.1"

--- a/rsproperties-service/Cargo.toml
+++ b/rsproperties-service/Cargo.toml
@@ -20,6 +20,7 @@ rsproperties = { path = "../rsproperties", features = ["builder"] }
 log.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+tokio-stream.workspace = true
 rsactor.workspace = true
 
 [dev-dependencies]

--- a/rsproperties-service/src/properties_service.rs
+++ b/rsproperties-service/src/properties_service.rs
@@ -90,6 +90,10 @@ fn init_system_properties_sync(
 impl Actor for PropertiesService {
     type Args = PropertiesServiceArgs;
     type Error = std::io::Error;
+    // This actor does no periodic / event-driven idle work, so the idle event
+    // type is unit and `on_idle` is left at its default no-op. (0.16 requires
+    // the associated type even when unused; manual impls must spell it out.)
+    type IdleEvent = ();
 
     async fn on_start(
         args: Self::Args,

--- a/rsproperties-service/src/socket_service.rs
+++ b/rsproperties-service/src/socket_service.rs
@@ -11,6 +11,8 @@ use tokio::fs;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::Semaphore;
+use tokio_stream::wrappers::UnixListenerStream;
+use tokio_stream::StreamExt;
 
 use rsactor::{Actor, ActorRef, ActorWeak};
 
@@ -51,7 +53,7 @@ const SOCKET_FILE_MODE: u32 = 0o660;
 
 /// Backoff applied when `accept()` returns an error. Without it, a
 /// permanent failure (EMFILE, ENFILE, listener torn down) would re-enter
-/// `on_run` immediately and spin the worker producing a high-rate log
+/// `on_idle` immediately and spin the worker producing a high-rate log
 /// flood. 100ms is short enough to recover quickly when the condition
 /// clears, long enough to dampen the loop.
 const ACCEPT_ERROR_BACKOFF: Duration = Duration::from_millis(100);
@@ -77,7 +79,12 @@ pub struct SocketServiceArgs {
 /// The actor can be stopped by calling `actor_ref.stop()` when the service is no longer needed.
 ///
 pub fn run(args: SocketServiceArgs) -> crate::ServiceContext<SocketService> {
-    let (actor_ref, join_handle) = rsactor::spawn(args);
+    // `with_idle()` is required in 0.16: the idle-event channel is opt-in, and
+    // this actor drives its accept loop through `subscribe_idle` / `on_idle`.
+    // Without it `subscribe_idle` would return `IdleChannelNotEnabled` and the
+    // listeners would never be polled.
+    let (actor_ref, join_handle) =
+        rsactor::spawn_with_options(args, rsactor::SpawnOptions::new().with_idle());
     crate::ServiceContext {
         actor_ref,
         join_handle,
@@ -87,8 +94,6 @@ pub fn run(args: SocketServiceArgs) -> crate::ServiceContext<SocketService> {
 /// Tokio-based property socket service
 pub struct SocketService {
     socket_dir: PathBuf,
-    property_listener: UnixListener,
-    system_listener: UnixListener,
     properties_service: ActorRef<crate::PropertiesService>,
     /// Limits concurrently in-flight client tasks.
     connection_sem: Arc<Semaphore>,
@@ -97,10 +102,15 @@ pub struct SocketService {
 impl Actor for SocketService {
     type Args = SocketServiceArgs;
     type Error = rsproperties::errors::Error;
+    /// Each idle event is one accepted connection (or an `accept()` error)
+    /// tagged with the listener it came from, so logging can name the source.
+    /// In 0.16 the accept loop is modelled as `Stream`s of connections
+    /// subscribed via `subscribe_idle`, replacing the removed `on_run`.
+    type IdleEvent = (std::io::Result<UnixStream>, &'static str);
 
     async fn on_start(
         args: Self::Args,
-        _actor_ref: &ActorRef<Self>,
+        actor_ref: &ActorRef<Self>,
     ) -> std::result::Result<Self, Self::Error> {
         // Create parent directory if it doesn't exist. `try_exists`
         // distinguishes "doesn't exist" (Ok(false)) from "couldn't ask"
@@ -152,54 +162,59 @@ impl Actor for SocketService {
         chmod_socket(&system_socket_path).await?;
         info!("AsyncPropertySocketService started successfully");
 
+        // Model each listener as a `Stream` of accepted connections and hand
+        // it to the actor's idle loop. The runtime owns the stream state, so
+        // — unlike the old `on_run` — accept progress is never lost to
+        // `select!` cancellation. Subscribing from `on_start` is safe:
+        // `subscribe_idle` is synchronous (`try_send`) and the runtime drains
+        // queued subscriptions before the first loop iteration.
+        actor_ref
+            .subscribe_idle(UnixListenerStream::new(property_listener).map(|r| (r, "property")))
+            .map_err(|e| std::io::Error::other(format!("subscribe property listener: {e}")))?;
+        actor_ref
+            .subscribe_idle(UnixListenerStream::new(system_listener).map(|r| (r, "system")))
+            .map_err(|e| std::io::Error::other(format!("subscribe system listener: {e}")))?;
+
         Ok(Self {
             socket_dir: args.socket_dir,
-            property_listener,
-            system_listener,
             properties_service: args.properties_service,
             connection_sem: Arc::new(Semaphore::new(MAX_CONCURRENT_CLIENTS)),
         })
     }
 
-    async fn on_run(
+    async fn on_idle(
         &mut self,
+        event: Self::IdleEvent,
         _actor_weak: &ActorWeak<Self>,
-    ) -> std::result::Result<bool, Self::Error> {
-        // Acquire the connection permit *before* accepting. Pre-acquire
-        // means once all 64 in-flight handlers are busy the accept loop
-        // simply parks here — new connect() attempts then queue in the
-        // kernel's listen backlog (and clients block in their own
-        // connect call) instead of completing the accept, sitting idle
-        // for up to CLIENT_TIMEOUT, and then failing. That's better
-        // observable behaviour and avoids fooling clients into thinking
-        // their request was accepted.
+    ) -> std::result::Result<(), Self::Error> {
+        let (accepted, source) = event;
+
+        let stream = match accepted {
+            Ok(stream) => stream,
+            Err(e) => {
+                // Permanent conditions (EMFILE, ENFILE, broken listener)
+                // would otherwise let the idle loop spin at full speed and
+                // saturate the log with the same error every microsecond. A
+                // small sleep both dampens the loop and gives the kernel time
+                // to recover the resource. `UnixListenerStream` keeps yielding
+                // after an error, so the listener is not lost.
+                error!("Error accepting connection on {source} listener: {e}");
+                tokio::time::sleep(ACCEPT_ERROR_BACKOFF).await;
+                return Ok(());
+            }
+        };
+
+        // Bound the number of concurrently in-flight client handlers. The old
+        // on_run acquired the permit *before* accepting; here the stream has
+        // already accepted one connection, so we acquire after. The idle loop
+        // is not polled again until this returns, so when all 64 permits are
+        // taken at most one extra connection is held here while the rest queue
+        // in the kernel's listen backlog — the same backpressure, off by one.
         let permit = match self.connection_sem.clone().acquire_owned().await {
             Ok(p) => p,
             Err(_) => {
                 error!("Connection semaphore closed");
-                return Ok(true);
-            }
-        };
-
-        // Race accept() on both listeners. Whichever fires first wins; the
-        // cancelled accept restarts on the next on_run cycle (accept is
-        // cancel-safe).
-        let (stream, source) = tokio::select! {
-            r = self.property_listener.accept() => (r, "property"),
-            r = self.system_listener.accept() => (r, "system"),
-        };
-
-        let (stream, _addr) = match stream {
-            Ok(ok) => ok,
-            Err(e) => {
-                // Permanent conditions (EMFILE, ENFILE, broken listener)
-                // would otherwise let `on_run` spin at full speed and
-                // saturate the log with the same error every microsecond.
-                // A small sleep both dampens the loop and gives the kernel
-                // time to recover the resource.
-                error!("Error accepting connection on {source} listener: {e}");
-                tokio::time::sleep(ACCEPT_ERROR_BACKOFF).await;
-                return Ok(true);
+                return Ok(());
             }
         };
 
@@ -219,7 +234,7 @@ impl Actor for SocketService {
                 }
             }
         });
-        Ok(true)
+        Ok(())
     }
 
     async fn on_stop(


### PR DESCRIPTION
## Summary

Upgrades `rsactor` **0.15 → 0.16** and fixes the resulting build breakage in `rsproperties-service`.

rsactor 0.16 removes `Actor::on_run` in favor of a stream-based `Actor::on_idle`, adds a required `Actor::IdleEvent` associated type, and makes the idle-event channel **opt-in** at spawn time.

## Changes

- **`SocketService`** — rewrote the accept loop:
  - Both Unix listeners are now modeled as `UnixListenerStream`s and registered via `ActorRef::subscribe_idle` in `on_start`.
  - Each accepted connection (or `accept()` error) is handled in `on_idle`, replacing the removed `on_run`. The runtime owns the stream state, so accept progress is no longer lost to `select!` cancellation.
  - Spawned via `spawn_with_options(.., SpawnOptions::new().with_idle())` since the idle channel is off by default in 0.16.
- **`PropertiesService`** — added `type IdleEvent = ();` (no periodic work; default no-op `on_idle`).
- Added **`tokio-stream`** (`net` feature) for `UnixListenerStream`.
- `Cargo.toml` / `Cargo.lock` version bumps.

The `rsproperties` crate is untouched — it does not depend on rsactor.

## Backpressure note

The old `on_run` acquired the connection semaphore permit *before* `accept()`. In the new model the stream accepts first, then `on_idle` acquires the permit; the idle loop isn't polled again until `on_idle` returns, so under saturation at most one extra connection is held while the rest queue in the kernel backlog — same backpressure, off by one.

## Testing

- `cargo build --workspace --all-targets` ✅
- `cargo clippy --workspace --all-targets` — clean ✅
- `cargo test --workspace` — all pass ✅

Verified on both **macOS** and **remote Linux (Arch, x86_64)**, including the service integration tests (`integration_tests`, `comprehensive_api_tests`, `error_handling_tests`, `example_usage_tests`) that exercise the new `on_idle` accept path end-to-end over real Unix sockets.

Not applicable to the Android emulator path: `rsproperties-service` is not an Android solution and is not built/tested there; the Android flow only covers the `rsproperties` crate, which is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)