### PR TITLE
feat!: AOSP-parity fixes for wait, SELinux labeling, restart, and V1 protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,55 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (pre-1.0: minor bumps may include API changes).
 
+## [0.5.0] - 2026-06-12
+
+Android-parity release: futex wait correctness, SELinux labeling, service
+restart support, and V1 wire-protocol support in the service.
+
+### Changed
+
+- **Breaking:** `SystemProperties::wait` now takes an `old_serial:
+  Option<u32>` parameter — `wait(index, old_serial, timeout)` — mirroring
+  bionic `__system_property_wait(pi, old_serial, …)`. Passing the serial
+  observed at read time closes the lost-wakeup window between reading a
+  value and entering the wait; `None` keeps the previous sample-at-entry
+  behavior.
+- `SystemProperties::new_area` now treats the target directory as
+  "build a fresh area": stale area files left by a previous writer
+  instance are removed before the exclusive create, so a service restart
+  over an existing directory succeeds (AOSP's fresh-/dev-tmpfs assumption
+  doesn't hold for arbitrary dirs). A `.writer_lock` file (non-blocking
+  exclusive `flock`, held for the writer's lifetime) makes a concurrent
+  second writer fail fast instead of silently destroying the first
+  writer's files.
+
+### Added
+
+- V1 (`PROP_MSG_SETPROP`) wire-protocol support in
+  `rsproperties-service`: fixed 128-byte frames are decoded with AOSP
+  parity (last byte of name/value forced to NUL) and answered V1-style —
+  connection close as the implicit ack, no status word.
+- Doc on `SystemProperties::add` stating the bionic-parity contract:
+  adding an existing name is a silent no-op that does not update the
+  value.
+
+### Fixed
+
+- `futex_wait` treated every syscall error as fatal. `EAGAIN` (the serial
+  changed between the caller's load and the wait — the common race) now
+  re-reads and returns the new serial like bionic; `EINTR` retries with
+  the remaining timeout; `ETIMEDOUT` returns `None` without logging an
+  error.
+- SELinux labeling never worked: the xattr name was the bare `"selinux"`
+  (kernel rejects it; the correct name is `"security.selinux"`,
+  bionic's `XATTR_NAME_SELINUX`), and per-context area files were created
+  with no context at all. `ContextNode` now carries its context and labels
+  the file on create, matching bionic `context_node::open`.
+- `ServiceWriter::send` issued a single `write_vectored` with no
+  short-write handling; a partial write would desynchronise the
+  length-prefixed protocol. It now loops until all bytes are written,
+  retrying on `EINTR`.
+
 ## [0.4.0] - 2026-05-27
 
 Hardening release: protocol correctness, panic-safety, allocation-free

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "rsproperties"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "android_system_properties",
  "anyhow",
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "rsproperties-service"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 authors = ["Jeff Kim <hiking90@gmail.com>"]
 license = "Apache-2.0"

--- a/rsproperties-service/src/socket_service.rs
+++ b/rsproperties-service/src/socket_service.rs
@@ -17,7 +17,9 @@ use tokio_stream::StreamExt;
 use rsactor::{Actor, ActorRef, ActorWeak};
 
 use rsproperties::errors::*;
-use rsproperties::wire::{PROP_ERROR, PROP_MSG_SETPROP2, PROP_SUCCESS};
+use rsproperties::wire::{
+    PROP_ERROR, PROP_MSG_SETPROP, PROP_MSG_SETPROP2, PROP_NAME_MAX, PROP_SUCCESS, PROP_VALUE_MAX,
+};
 
 /// Upper bound on simultaneously serviced client connections. Each accepted
 /// connection takes one permit from the semaphore; further connections wait
@@ -288,6 +290,10 @@ impl SocketService {
         debug!("Received command: 0x{cmd:08X}");
 
         match cmd {
+            PROP_MSG_SETPROP => {
+                trace!("Processing SETPROP (V1) command");
+                Self::handle_setprop_v1(&mut stream, service).await?;
+            }
             PROP_MSG_SETPROP2 => {
                 trace!("Processing SETPROP2 command");
                 Self::handle_setprop2(&mut stream, service).await?;
@@ -300,6 +306,54 @@ impl SocketService {
 
         trace!("Client connection handled successfully");
         Ok(())
+    }
+
+    /// Handles the legacy V1 SETPROP command: after the already-consumed
+    /// command word, a fixed-size payload of `PROP_NAME_MAX` name bytes and
+    /// `PROP_VALUE_MAX` value bytes, both NUL-padded.
+    ///
+    /// V1 clients (bionic included) never read a status reply — closing the
+    /// connection is the implicit ack — so failures are logged and the
+    /// connection is closed without a response. Validation still happens in
+    /// `PropertiesService::handle`, identical to the V2 path.
+    async fn handle_setprop_v1(
+        stream: &mut UnixStream,
+        service: ActorRef<crate::PropertiesService>,
+    ) -> Result<()> {
+        trace!("Handling SETPROP (V1) request");
+
+        let mut name_buf = [0u8; PROP_NAME_MAX];
+        stream.read_exact(&mut name_buf).await?;
+        let mut value_buf = [0u8; PROP_VALUE_MAX];
+        stream.read_exact(&mut value_buf).await?;
+        // AOSP V1 parity: init forces the last byte of both fields to NUL
+        // before use (`prop_name[PROP_NAME_MAX-1] = 0`), capping names at
+        // 31 chars and values at 91 bytes. Without this a non-bionic client
+        // could submit a 32-char name that AOSP would have truncated.
+        name_buf[PROP_NAME_MAX - 1] = 0;
+        value_buf[PROP_VALUE_MAX - 1] = 0;
+
+        let name = Self::string_from_fixed(&name_buf)?;
+        let value = Self::string_from_fixed(&value_buf)?;
+        info!("Forwarding V1 property: '{name}' ({} bytes)", value.len());
+
+        let property_msg = crate::PropertyMessage { name, value };
+        match service.ask(property_msg).await {
+            Ok(true) => {}
+            // The property name was already logged by the `info!` above;
+            // mirroring the V2 handler, the result logs omit it.
+            Ok(false) => warn!("V1 property was rejected by service"),
+            Err(e) => error!("Failed to forward V1 property: {e}"),
+        }
+
+        Ok(())
+    }
+
+    /// Decodes a fixed-size NUL-padded V1 wire field into a `String`.
+    fn string_from_fixed(buf: &[u8]) -> Result<String> {
+        let end = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
+        String::from_utf8(buf[..end].to_vec())
+            .map_err(|e| rsproperties::errors::Error::Encoding(e.to_string()))
     }
 
     /// Handles SETPROP2 command

--- a/rsproperties-service/tests/performance_tests.rs
+++ b/rsproperties-service/tests/performance_tests.rs
@@ -148,6 +148,13 @@ async fn test_large_property_values() -> Result<()> {
     // Test with various sizes approaching PROP_VALUE_MAX
     let sizes = vec![10, 50, 80, rsproperties::PROP_VALUE_MAX - 5];
 
+    // Warm-up: the first set() pays one-time costs (socket connect, the
+    // service's lazy property-area open) that are unrelated to the
+    // size-scaling property asserted below. Without it the first timed
+    // iteration occasionally exceeds the 10ms bound under full-workspace
+    // test load.
+    rsproperties::set("perf.large.prop.warmup", "warmup")?;
+
     for size in sizes {
         let prop_name = format!("perf.large.prop.{size}");
         let large_value = "x".repeat(size);

--- a/rsproperties-service/tests/v1_protocol_tests.rs
+++ b/rsproperties-service/tests/v1_protocol_tests.rs
@@ -1,0 +1,54 @@
+// Copyright 2024 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end test for the legacy V1 (`PROP_MSG_SETPROP`) wire protocol.
+//!
+//! V1 is a fixed-size frame — cmd word + `PROP_NAME_MAX` name bytes +
+//! `PROP_VALUE_MAX` value bytes, NUL-padded — and the client treats the
+//! server closing the connection as the ack (no status reply). The server
+//! previously only understood SETPROP2, so a V1 client appeared to succeed
+//! while the set was silently dropped.
+
+mod common;
+use common::init_test;
+
+use tokio::io::AsyncReadExt;
+use tokio::io::AsyncWriteExt;
+use tokio::net::UnixStream;
+
+use rsproperties::wire::{PROP_MSG_SETPROP, PROP_NAME_MAX, PROP_VALUE_MAX};
+
+fn fixed<const N: usize>(s: &str) -> [u8; N] {
+    let mut buf = [0u8; N];
+    buf[..s.len()].copy_from_slice(s.as_bytes());
+    buf
+}
+
+#[tokio::test]
+async fn test_v1_setprop_roundtrip() {
+    let _ = init_test().await;
+
+    let socket_path = rsproperties::socket_dir().join(rsproperties::PROPERTY_SERVICE_SOCKET_NAME);
+    let mut stream = UnixStream::connect(&socket_path)
+        .await
+        .expect("connect to property_service socket");
+
+    let name = "test.v1.property";
+    let value = "v1_value";
+
+    let mut msg = Vec::with_capacity(4 + PROP_NAME_MAX + PROP_VALUE_MAX);
+    msg.extend_from_slice(&PROP_MSG_SETPROP.to_ne_bytes());
+    msg.extend_from_slice(&fixed::<PROP_NAME_MAX>(name));
+    msg.extend_from_slice(&fixed::<PROP_VALUE_MAX>(value));
+    stream.write_all(&msg).await.expect("send V1 frame");
+    stream.shutdown().await.expect("half-close write side");
+
+    // V1 ack is the server closing the connection after processing.
+    let mut sink = Vec::new();
+    stream.read_to_end(&mut sink).await.expect("await close");
+
+    // `handle_client` forwards to the properties service before returning,
+    // so once the socket is closed the property must be visible.
+    let read: String = rsproperties::get(name).expect("property set via V1");
+    assert_eq!(read, value);
+}

--- a/rsproperties/src/context_node.rs
+++ b/rsproperties/src/context_node.rs
@@ -1,6 +1,7 @@
 // Copyright 2024 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
+use std::ffi::CString;
 use std::path::PathBuf;
 #[cfg(feature = "builder")]
 use std::sync::RwLockWriteGuard;
@@ -13,6 +14,13 @@ use crate::property_area::PropertyAreaMap;
 
 pub(crate) struct ContextNode {
     access_rw: bool,
+    /// SELinux context this area belongs to (e.g.
+    /// `u:object_r:system_prop:s0`). Applied as the `security.selinux`
+    /// xattr when the area file is created read-write, mirroring bionic's
+    /// `context_node::open` which labels each per-context file. `Some`
+    /// only for writable nodes — read-only instances never label files,
+    /// so they skip the allocation.
+    context: Option<CString>,
     filename: PathBuf,
     /// Lazy-initialized property area. Once a writer puts `Some`, no code
     /// path ever resets it to `None` — this is the invariant that lets the
@@ -23,9 +31,10 @@ pub(crate) struct ContextNode {
 }
 
 impl ContextNode {
-    pub(crate) fn new(access_rw: bool, filename: PathBuf) -> Self {
+    pub(crate) fn new(access_rw: bool, context: Option<CString>, filename: PathBuf) -> Self {
         Self {
             access_rw,
+            context,
             filename,
             property_area: RwLock::new(None),
         }
@@ -50,7 +59,7 @@ impl ContextNode {
 
         *prop_area = Some(PropertyAreaMap::new_rw(
             self.filename.as_path(),
-            None,
+            self.context.as_deref(),
             fsetxattr_failed,
         )?);
 

--- a/rsproperties/src/contexts_serialized.rs
+++ b/rsproperties/src/contexts_serialized.rs
@@ -25,8 +25,16 @@ fn try_build_context_node(
     i: usize,
 ) -> Result<ContextNode> {
     let context_offset = area.context_offset(i)?;
-    let context_name = area.cstr(context_offset).to_str()?;
-    Ok(ContextNode::new(writable, dirname.join(context_name)))
+    let context_cstr = area.cstr(context_offset);
+    let context_name = context_cstr.to_str()?;
+    // The owned context is only consumed by `open()` (writable path) for
+    // SELinux labeling; read-only nodes skip the allocation.
+    let context = writable.then(|| context_cstr.to_owned());
+    Ok(ContextNode::new(
+        writable,
+        context,
+        dirname.join(context_name),
+    ))
 }
 
 // Pre-defined CStr constants to avoid unsafe code at runtime
@@ -40,6 +48,13 @@ pub(crate) struct ContextsSerialized {
     /// property-info parser line up with the vector's indices.
     context_nodes: Vec<Option<ContextNode>>,
     serial_property_area_map: PropertyAreaMap,
+    /// Exclusive `flock` held for the lifetime of a writable instance
+    /// (`None` when read-only). `PropertyAreaMap::new_rw` unlinks and
+    /// recreates stale area files, so without this lock a second writer
+    /// would silently destroy the files the first one still owns; with it,
+    /// the loser fails fast before touching anything. The kernel drops the
+    /// lock when the `File` closes — including on crash.
+    _writer_lock: Option<std::fs::File>,
 }
 
 impl ContextsSerialized {
@@ -73,7 +88,7 @@ impl ContextsSerialized {
             }
         }
 
-        let serial_property_area_map = if writable {
+        let (writer_lock, serial_property_area_map) = if writable {
             if !dirname.is_dir() {
                 info!("Creating directory: {dirname:?}");
                 fs::mkdir(
@@ -83,22 +98,55 @@ impl ContextsSerialized {
                 .map_err(Error::from)?;
             }
 
+            // Must precede the `open()` calls below: they unlink and
+            // recreate area files, so a losing second writer has to bail
+            // out *before* touching anything the winner owns.
+            let lock = Self::acquire_writer_lock(dirname.as_path())?;
+
             *fsetxattr_failed = false;
 
             for node in context_nodes.iter_mut().flatten() {
                 node.open(fsetxattr_failed)?;
             }
 
-            Self::map_serial_property_area(serial_filename.as_path(), true, fsetxattr_failed)?
+            (
+                Some(lock),
+                Self::map_serial_property_area(serial_filename.as_path(), true, fsetxattr_failed)?,
+            )
         } else {
-            Self::map_serial_property_area(serial_filename.as_path(), false, fsetxattr_failed)?
+            (
+                None,
+                Self::map_serial_property_area(serial_filename.as_path(), false, fsetxattr_failed)?,
+            )
         };
 
         Ok(Self {
             property_info_area_file,
             context_nodes,
             serial_property_area_map,
+            _writer_lock: writer_lock,
         })
+    }
+
+    /// Opens (creating if needed) `<dirname>/.writer_lock` and takes a
+    /// non-blocking exclusive `flock`. The lock lives exactly as long as
+    /// the returned `File`, so holding it in the struct scopes single-writer
+    /// ownership of the directory to the instance's lifetime.
+    fn acquire_writer_lock(dirname: &Path) -> Result<std::fs::File> {
+        let lock_path = dirname.join(".writer_lock");
+        let lock_file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)
+            .context_with_location(format!("Failed to open writer lock {lock_path:?}"))?;
+        fs::flock(&lock_file, fs::FlockOperation::NonBlockingLockExclusive).map_err(|e| {
+            error!("Another writer holds the property area lock {lock_path:?}: {e}");
+            Error::LockError(format!(
+                "Writable property area already owned by another instance ({lock_path:?}): {e}"
+            ))
+        })?;
+        Ok(lock_file)
     }
 
     fn map_serial_property_area(

--- a/rsproperties/src/lib.rs
+++ b/rsproperties/src/lib.rs
@@ -658,7 +658,7 @@ mod tests {
             let system_properties = system_properties();
             let index = system_properties.find(test_prop).unwrap();
             // let serial = system_properties.serial(index.as_ref().unwrap());
-            system_properties.wait(index.as_ref(), None);
+            system_properties.wait(index.as_ref(), None, None);
         });
 
         let handle_any = wait_any();

--- a/rsproperties/src/property_area.rs
+++ b/rsproperties/src/property_area.rs
@@ -114,6 +114,20 @@ impl PropertyAreaMap {
     ) -> Result<Self> {
         debug!("Creating new read-write property area map: {filename:?}");
 
+        // A leftover area file from a previous writer instance would make
+        // the O_EXCL create below fail — and the 0444 mode means it could
+        // not be reopened read-write either. AOSP avoids this via the fresh
+        // tmpfs mounted at /dev on every boot; that assumption doesn't hold
+        // for an arbitrary properties dir, so treat `new_rw` as "build a
+        // fresh area" and remove any stale file first. O_EXCL still guards
+        // the create itself (no symlink / pre-created-file substitution
+        // between the unlink and the open).
+        match std::fs::remove_file(filename) {
+            Ok(()) => debug!("Removed stale property area file: {filename:?}"),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => warn!("Failed to remove stale property area file {filename:?}: {e}"),
+        }
+
         let file = OpenOptions::new()
             .read(true) // O_RDWR
             .write(true) // O_RDWR
@@ -123,9 +137,13 @@ impl PropertyAreaMap {
             .open(filename)?;
 
         if let Some(context) = context {
+            // Full xattr name required — the bare "selinux" (no namespace
+            // prefix) is rejected by the kernel with EOPNOTSUPP, which made
+            // this call fail unconditionally. bionic uses XATTR_NAME_SELINUX,
+            // which is "security.selinux".
             if fs::fsetxattr(
                 &file,
-                "selinux",
+                "security.selinux",
                 context.to_bytes_with_nul(),
                 fs::XattrFlags::empty(),
             )

--- a/rsproperties/src/system_properties.rs
+++ b/rsproperties/src/system_properties.rs
@@ -34,9 +34,14 @@ fn futex_wake(_addr: &AtomicU32) -> Result<usize> {
     Ok(0)
 }
 
+/// Waits until `_serial` differs from `_value`, returning the new serial.
+///
+/// Returns `None` on timeout (or on macOS, where no futex is available and
+/// this is an immediate no-op — see `SystemProperties::wait`).
 fn futex_wait(_serial: &AtomicU32, _value: u32, _timeout: Option<&Timespec>) -> Option<u32> {
     #[cfg(any(target_os = "android", target_os = "linux"))]
     {
+        use rustix::io::Errno;
         // Linux futex_wait takes a *relative* timeout. Spurious wakes restart
         // the syscall, so we track a deadline and shrink the remaining timeout
         // each iteration to keep the total wait bounded by the caller-supplied
@@ -79,6 +84,25 @@ fn futex_wait(_serial: &AtomicU32, _value: u32, _timeout: Option<&Timespec>) -> 
                     }
                     // Spurious wake — loop with the recomputed remaining timeout.
                 }
+                // EAGAIN: the serial no longer equals `_value` at syscall
+                // time — i.e. the property changed between the caller's load
+                // and the wait. This is the *common* race, not a failure;
+                // bionic's wait loop falls through to the serial re-check
+                // and reports success. Treating it as an error here would
+                // silently swallow a real property change.
+                Err(Errno::AGAIN) => {
+                    let new_serial = _serial.load(Ordering::Acquire);
+                    if _value != new_serial {
+                        return Some(new_serial);
+                    }
+                    // Serial changed and wrapped back to `_value` between the
+                    // syscall and the reload — vanishingly unlikely; retry.
+                }
+                // Interrupted by a signal — retry with the recomputed
+                // remaining timeout so the total wait stays bounded.
+                Err(Errno::INTR) => {}
+                // Timeout is a normal outcome, not an error worth logging.
+                Err(Errno::TIMEDOUT) => return None,
                 Err(e) => {
                     log::error!("Failed to wait for property change: {e}");
                     return None;
@@ -400,6 +424,12 @@ impl SystemProperties {
         Ok(true)
     }
 
+    /// Adds a new property.
+    ///
+    /// If a property with `name` already exists this is a silent no-op that
+    /// returns `Ok(())` **without** updating the value — the same contract
+    /// as bionic `prop_area::add`. Use [`Self::set`] (or `find` +
+    /// [`Self::update`]) for create-or-update semantics.
     #[cfg(feature = "builder")]
     pub fn add(&mut self, name: &str, value: &str) -> Result<()> {
         // Shared policy across client/server: only `ro.` names may exceed
@@ -475,18 +505,43 @@ impl SystemProperties {
         Some(pi.serial.load(Ordering::Acquire))
     }
 
+    /// Waits for any property to change. Equivalent to
+    /// `wait(None, None, None)`; see [`Self::wait`] for the race caveat of
+    /// not passing an `old_serial`.
     pub fn wait_any(&self) -> Option<u32> {
-        self.wait(None, None)
+        self.wait(None, None, None)
     }
 
-    pub fn wait(&self, index: Option<&PropertyIndex>, timeout: Option<&Timespec>) -> Option<u32> {
+    /// Waits until the property at `index` (or, with `index == None`, the
+    /// global serial — i.e. any property) changes, returning the new serial.
+    /// Returns `None` on timeout or lookup failure.
+    ///
+    /// `old_serial` should be the serial observed when the caller last read
+    /// the value (via [`Self::serial`] / [`Self::context_serial`]). Passing
+    /// `Some` closes the lost-wakeup window between reading a value and
+    /// entering the wait: if the property already changed since
+    /// `old_serial`, this returns immediately with the new serial — the
+    /// same contract as bionic `__system_property_wait(pi, old_serial, …)`.
+    /// With `None`, the current serial is sampled at entry, so a change
+    /// that lands before this call is only observed at the *next* change.
+    ///
+    /// On macOS there is no futex; this returns `None` immediately, so do
+    /// not call it in a polling loop there.
+    pub fn wait(
+        &self,
+        index: Option<&PropertyIndex>,
+        old_serial: Option<u32>,
+        timeout: Option<&Timespec>,
+    ) -> Option<u32> {
         match index {
             Some(idx) => match self.contexts.prop_area_with_index(idx.context_index).ok() {
                 Some(guard) => {
                     let pa = guard.property_area();
                     match pa.property_info(idx.property_index).ok() {
                         Some(pi) => {
-                            futex_wait(&pi.serial, pi.serial.load(Ordering::Acquire), timeout)
+                            let old =
+                                old_serial.unwrap_or_else(|| pi.serial.load(Ordering::Acquire));
+                            futex_wait(&pi.serial, old, timeout)
                         }
                         None => {
                             log::error!(
@@ -507,7 +562,8 @@ impl SystemProperties {
             },
             None => {
                 let serial_pa = self.contexts.serial_prop_area().serial();
-                futex_wait(serial_pa, serial_pa.load(Ordering::Acquire), timeout)
+                let old = old_serial.unwrap_or_else(|| serial_pa.load(Ordering::Acquire));
+                futex_wait(serial_pa, old, timeout)
             }
         }
     }

--- a/rsproperties/src/system_property_set.rs
+++ b/rsproperties/src/system_property_set.rs
@@ -114,7 +114,11 @@ impl ServiceConnection {
 }
 
 struct ServiceWriter<'a> {
-    buffers: Vec<IoSlice<'a>>,
+    // Raw byte slices rather than `IoSlice`s: the short-write loop in
+    // `send` needs to re-slice past already-written bytes, and `IoSlice`
+    // doesn't expose its inner slice on stable (`advance_slices` is
+    // 1.81+, above this crate's MSRV).
+    buffers: Vec<&'a [u8]>,
 }
 
 impl<'a> ServiceWriter<'a> {
@@ -126,24 +130,52 @@ impl<'a> ServiceWriter<'a> {
 
     fn write_str(self, value: &'a str, len: &'a u32) -> Self {
         let mut thiz = self.write_u32(len);
-        thiz.buffers.push(IoSlice::new(value.as_bytes()));
+        thiz.buffers.push(value.as_bytes());
         thiz
     }
 
     fn write_u32(mut self, value: &'a u32) -> Self {
-        self.buffers.push(IoSlice::new(value.as_bytes()));
+        self.buffers.push(value.as_bytes());
         self
     }
 
     fn write_bytes(mut self, value: &'a [u8]) -> Self {
-        self.buffers.push(IoSlice::new(value));
+        self.buffers.push(value);
         self
     }
 
     fn send(self, conn: &mut ServiceConnection) -> Result<()> {
-        conn.stream
-            .write_vectored(&self.buffers)
-            .map_err(Error::Io)?;
+        // A single `write_vectored` may write fewer bytes than requested
+        // (signal after a partial transfer, full socket buffer). Loop until
+        // every byte is on the wire — a short write would otherwise
+        // desynchronise the length-prefixed protocol and leave the server
+        // waiting for bytes that never arrive.
+        let total: usize = self.buffers.iter().map(|b| b.len()).sum();
+        let mut written = 0usize;
+        while written < total {
+            // Rebuild the IoSlice list, skipping what already went out.
+            let mut skip = written;
+            let mut slices: Vec<IoSlice<'_>> = Vec::with_capacity(self.buffers.len());
+            for buf in &self.buffers {
+                if skip >= buf.len() {
+                    skip -= buf.len();
+                    continue;
+                }
+                slices.push(IoSlice::new(&buf[skip..]));
+                skip = 0;
+            }
+            match conn.stream.write_vectored(&slices) {
+                Ok(0) => {
+                    return Err(Error::Io(std::io::Error::new(
+                        std::io::ErrorKind::WriteZero,
+                        "property service socket closed mid-write",
+                    )))
+                }
+                Ok(n) => written += n,
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {}
+                Err(e) => return Err(Error::Io(e)),
+            }
+        }
         conn.stream.flush()?;
         Ok(())
     }

--- a/rsproperties/tests/area_restart_tests.rs
+++ b/rsproperties/tests/area_restart_tests.rs
@@ -1,0 +1,96 @@
+// Copyright 2024 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+//! Regression test for writer re-initialisation over an existing directory.
+//!
+//! `PropertyAreaMap::new_rw` creates area files with `O_EXCL` and mode
+//! `0444` (matching bionic). AOSP gets away with that because /dev is a
+//! fresh tmpfs on every boot; for an arbitrary properties dir a leftover
+//! file from a previous service instance used to make every second
+//! `SystemProperties::new_area` fail with EEXIST — and the 0444 mode meant
+//! the file couldn't be reopened read-write either. `new_rw` now removes
+//! stale files before the exclusive create.
+
+#![cfg(all(feature = "builder", not(target_os = "android")))]
+
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+use rsproperties::{build_trie, PropertyInfoEntry, SystemProperties};
+
+fn build_property_info(dir: &Path) {
+    std::fs::create_dir_all(dir).unwrap();
+
+    let contexts_path = dir.join("property_contexts");
+    File::create(&contexts_path)
+        .unwrap()
+        .write_all(b"test. u:object_r:test_prop:s0 prefix string\n")
+        .unwrap();
+
+    let (entries, errors) = PropertyInfoEntry::parse_from_file(&contexts_path, false).unwrap();
+    assert!(errors.is_empty(), "parse errors: {errors:?}");
+
+    let data = build_trie(&entries, "u:object_r:default_prop:s0", "string").unwrap();
+    File::create(dir.join("property_info"))
+        .unwrap()
+        .write_all(&data)
+        .unwrap();
+}
+
+#[test]
+fn test_new_area_restart_over_existing_dir() {
+    let dir = std::env::temp_dir().join(format!("rsprops_restart_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    build_property_info(&dir);
+
+    {
+        let mut props = SystemProperties::new_area(&dir).expect("first new_area");
+        props.add("test.restart", "1").unwrap();
+        assert_eq!(props.get_with_result("test.restart").unwrap(), "1");
+    }
+
+    // Simulates a service restart: the dir still holds the context area
+    // files and properties_serial from the first instance. This used to
+    // fail with EEXIST.
+    let mut props = SystemProperties::new_area(&dir).expect("second new_area over existing dir");
+
+    // The rebuilt area starts fresh — the old entry must be gone, and a
+    // new add must land in the new mapping.
+    assert!(props.find("test.restart").unwrap().is_none());
+    props.add("test.restart", "2").unwrap();
+    assert_eq!(props.get_with_result("test.restart").unwrap(), "2");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_concurrent_writer_rejected_by_lock() {
+    let dir = std::env::temp_dir().join(format!("rsprops_wlock_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    build_property_info(&dir);
+
+    let first = SystemProperties::new_area(&dir).expect("first writer");
+
+    // While the first writer is alive, a second writer must fail fast on
+    // the `.writer_lock` flock — *before* unlinking any of the area files
+    // the first writer owns.
+    let second = SystemProperties::new_area(&dir);
+    assert!(
+        second.is_err(),
+        "second concurrent writer must be rejected by the writer lock"
+    );
+
+    // The loser must not have destroyed the winner's files: the first
+    // instance keeps working.
+    drop(second);
+    let mut first = first;
+    first.add("test.lock", "alive").unwrap();
+    assert_eq!(first.get_with_result("test.lock").unwrap(), "alive");
+
+    // Releasing the first writer releases the flock; a new writer succeeds.
+    drop(first);
+    SystemProperties::new_area(&dir).expect("writer after lock release");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/rsproperties/tests/property_change_wait_tests.rs
+++ b/rsproperties/tests/property_change_wait_tests.rs
@@ -77,7 +77,7 @@ fn test_wait_for_property_change() {
 
                         // Wait for property change (no timeout)
                         println!("Waiter thread: Now waiting for property change...");
-                        match system_properties.wait(Some(&index), None) {
+                        match system_properties.wait(Some(&index), None, None) {
                             Some(_serial) => {
                                 // Wait completed successfully
                                 let new_value =


### PR DESCRIPTION
## Summary

Source review against AOSP bionic `system_properties` / init `property_service` surfaced several correctness gaps; this PR fixes all confirmed findings. Version is bumped to **0.5.0** (one breaking API change).

### Fixed
- **`futex_wait` swallowed real property changes**: `EAGAIN` (serial changed between the caller's load and the syscall — the common race) was treated as a fatal error returning `None`. It now re-reads and returns the new serial like bionic; `EINTR` retries with the remaining timeout; `ETIMEDOUT` returns `None` without an error log.
- **SELinux labeling never worked**: the xattr name was the bare `"selinux"` (kernel rejects it; bionic uses `XATTR_NAME_SELINUX` = `"security.selinux"`), and per-context area files were created with no context at all. `ContextNode` now carries its context and labels files on create, matching bionic `context_node::open`.
- **Service restart over an existing directory failed** (`O_EXCL` + 0444 leftovers): `new_rw` now removes stale area files first, and a `.writer_lock` (non-blocking exclusive `flock`, held for the writer's lifetime) makes a concurrent second writer fail fast instead of silently destroying the first writer's files.
- **Short-write handling in the set client**: `ServiceWriter::send` issued a single `write_vectored`; a partial write would desynchronise the length-prefixed protocol. It now loops until complete, retrying on `EINTR`.

### Added
- **V1 (`PROP_MSG_SETPROP`) support in the service** with AOSP parity (last name/value byte forced to NUL, connection close as the implicit ack). Previously a V1 client appeared to succeed while the set was silently dropped.

### Changed (breaking)
- `SystemProperties::wait` now takes `old_serial: Option<u32>` — `wait(index, old_serial, timeout)` — mirroring bionic `__system_property_wait` and closing the read-to-wait lost-wakeup window. `None` keeps the previous behavior.

### Tests
- `area_restart_tests`: restart over stale files + concurrent-writer rejection via the flock.
- `v1_protocol_tests`: raw-socket V1 frame → service → `get()` round trip.
- Warm-up added to the large-value perf test to drop cold-start noise from its 10ms timing bound.

## Verification

- macOS: `cargo test --workspace --all-features` — 196 passed, 0 failed; clippy clean.
- Native Linux (x86_64): full suite 3 consecutive runs — 196 passed, 0 failed; exercises futex paths, the V1 server round trip, and the writer lock natively.
- Android 16 emulator (arm64-v8a): all on-device suites pass, including `property_change_wait_tests` (futex fix against real prop areas), read-path comparison against bionic for 40 real properties, and both V1/V2 clients interoperating with the real AOSP `property_service`.