### PR TITLE
deps: bump rsactor from 0.16 to 0.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,9 +485,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rsactor"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8fe40ccb56316045667a08fa7fb562e4b5601fb332613dcf370cd6c40487f8"
+checksum = "1e409868dbe4fcb07613291c6894399a38fb55fdf07bf42feecd612fb471461a"
 dependencies = [
  "futures",
  "rsactor-derive",
@@ -497,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "rsactor-derive"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97e063567221ff983eb14a55b214bc33976ca8148a4d3017186d54426bf25e6"
+checksum = "e01bc4ce87993a9874d413bd300b73e57282a89d658f799cae248a6ec47cc841"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ anyhow = "1.0"
 pretty-hex = "0.4"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time", "net", "io-util", "signal", "fs"] }
 tokio-stream = { version = "0.1", features = ["net"] }
-rsactor = "0.16"
+rsactor = "0.17"
 
 # Dev dependencies
 android_system_properties = "0.1"


### PR DESCRIPTION
## Summary

Bumps `rsactor` 0.16 → 0.17.0.

0.17 is a breaking release (`ActorResult::Failed` reworked into a phase-specific `ActorFailure` payload, `subscribe_idle` return type changed, `Actor::Error: Display` now required), but none of these touch this crate's API surface:

- `ActorResult<T>` is only used as the opaque payload of `JoinHandle<ActorResult<T>>` — the `Failed` internals are never accessed.
- `subscribe_idle` is already handled via `.map_err(...)?`, compatible with the new `Result<(), IdleSubscribeError<T>>` return type.
- Both `Actor::Error` types — `rsproperties::errors::Error` (thiserror derives `Display`) and `std::io::Error` — already implement `Display`.

Version bump only; no source changes required.

## Verification

- `cargo build --workspace --all-features` and clippy (all-targets): clean.
- Tests: macOS 196/196, native Linux (x86_64) 196/196.